### PR TITLE
[17] add menu group on CoconutPullDown & update CoconutTextField placeholder

### DIFF
--- a/example/lib/screens/inputs.dart
+++ b/example/lib/screens/inputs.dart
@@ -35,282 +35,281 @@ class _InputsScreenState extends State<InputsScreen> {
 
   @override
   Widget build(BuildContext context) {
-    return Scaffold(
-      appBar: const MyAppBar(),
-      body: SingleChildScrollView(
-        child: Consumer<ThemeProvider>(
-          builder: (context, themeProvider, child) {
-            final isDarkMode = themeProvider.themeMode == ThemeMode.dark;
-            final brightness = isDarkMode ? Brightness.dark : Brightness.light;
+    return GestureDetector(
+      onTap: () => FocusScope.of(context).unfocus(),
+      child: Scaffold(
+        appBar: const MyAppBar(),
+        body: SingleChildScrollView(
+          child: Consumer<ThemeProvider>(
+            builder: (context, themeProvider, child) {
+              final isDarkMode = themeProvider.themeMode == ThemeMode.dark;
+              final brightness = isDarkMode ? Brightness.dark : Brightness.light;
 
-            return Padding(
-              padding: const EdgeInsets.all(CoconutLayout.defaultPadding),
-              child: Center(
-                child: Column(
-                  children: [
-                    _titleBox('Chip', brightness),
-                    Wrap(
-                      spacing: 10,
-                      runAlignment: WrapAlignment.center,
-                      runSpacing: 10,
-                      crossAxisAlignment: WrapCrossAlignment.center,
-                      children: [
-                        const CoconutChip(
-                          color: CoconutColors.primary,
-                          label: 'TEXT',
-                          labelColor: CoconutColors.black,
-                          labelSize: 10,
-                          isSelected: true,
-                        ),
-                        CoconutChip(
-                          color: CoconutColors.onGray150(brightness),
-                          label: 'TEXT',
-                          labelColor: CoconutColors.onBlack(brightness),
-                          labelSize: 10,
-                          isSelected: true,
-                        ),
-                        CoconutChip(
-                          color: Colors.transparent,
-                          label: 'TEXT3',
-                          labelColor: CoconutColors.onBlack(brightness),
-                          labelSize: 10,
-                          borderColor: CoconutColors.onBlack(brightness),
-                          isSelected: true,
-                        ),
-                        const CoconutChip(
-                          color: CoconutColors.cyan,
-                          padding:
-                              EdgeInsets.symmetric(vertical: 2, horizontal: 8),
-                          isRectangle: true,
-                          label: 'TESTNET',
-                          labelColor: CoconutColors.white,
-                          labelSize: 10,
-                          isSelected: true,
-                        ),
-                        CoconutChip(
-                          color: CoconutColors.colorPalette.first,
-                          padding: const EdgeInsets.symmetric(
-                              vertical: 2, horizontal: 8),
-                          label: 'isSelected null',
-                          labelColor: CoconutColors.colorPalette.first,
-                          labelSize: 12,
-                          hasOpacity: true,
-                        ),
-                        CoconutChip(
-                          color: CoconutColors.colorPalette.last,
-                          padding: const EdgeInsets.symmetric(
-                              vertical: 2, horizontal: 8),
-                          label: 'Selected',
-                          labelColor: CoconutColors.colorPalette.last,
-                          labelSize: 10,
-                          hasOpacity: true,
-                          isSelected: true,
-                        ),
-                        CoconutChip(
-                          color: CoconutColors.colorPalette.last,
-                          padding: const EdgeInsets.symmetric(
-                              vertical: 2, horizontal: 8),
-                          label: 'Unselected',
-                          labelColor: CoconutColors.colorPalette.last,
-                          labelSize: 10,
-                          hasOpacity: true,
-                          isSelected: false,
-                        )
-                      ],
-                    ),
-                    CoconutLayout.spacing_600h,
-                    _titleBox('Tag Chip', brightness),
-                    Wrap(
-                      spacing: 10,
-                      runAlignment: WrapAlignment.center,
-                      runSpacing: 10,
-                      crossAxisAlignment: WrapCrossAlignment.center,
-                      children: [
-                        const CoconutTagChip(
-                          tag: 'TEXT',
-                          color: CoconutColors.red,
-                          isRectangle: true,
-                        ),
-                        CoconutTagChip(
-                          tag: 'TEXT',
-                          color: CoconutColors.red,
-                          status: chipStatus,
-                          onTap: (value) {
-                            if (chipStatus == CoconutChipStatus.unselected) {
-                              chipStatus = CoconutChipStatus.selected;
-                            } else {
-                              chipStatus = CoconutChipStatus.unselected;
-                            }
-                            setState(() {});
-                          },
-                        ),
-                      ],
-                    ),
-                    CoconutLayout.spacing_600h,
-                    _titleBox('Checkbox', brightness),
-                    Row(
-                      mainAxisAlignment: MainAxisAlignment.center,
-                      children: [
-                        CoconutCheckbox(
-                          isSelected: isCheckbox1Selected,
-                          onChanged: (value) {
-                            isCheckbox1Selected = value;
-                            setState(() {});
-                          },
-                        ),
-                        const SizedBox(width: 10),
-                        CoconutCheckbox(
-                          isSelected: isCheckbox2Selected,
-                          color: CoconutColors.primary,
-                          onChanged: (value) {
-                            isCheckbox2Selected = value;
-                            setState(() {});
-                          },
-                        ),
-                      ],
-                    ),
-                    CoconutLayout.spacing_600h,
-                    _titleBox('Switch', brightness),
-                    Row(
-                      mainAxisAlignment: MainAxisAlignment.center,
-                      children: [
-                        CoconutSwitch(
-                          isOn: isSwitch1On,
-                          onChanged: (value) {
-                            isSwitch1On = value;
-                            setState(() {});
-                          },
-                        ),
-                        const SizedBox(width: 10),
-                        CoconutSwitch(
-                          isOn: isSwitch2On,
-                          activeColor: CoconutColors.primary,
-                          thumbColor: CoconutColors.white,
-                          onChanged: (value) {
-                            isSwitch2On = value;
-                            setState(() {});
-                          },
-                        ),
-                      ],
-                    ),
-                    CoconutLayout.spacing_600h,
-                    _titleBox('Stepper', brightness),
-                    CoconutStepper(
-                      maxCount: 3,
-                      onCount: (count) {},
-                    ),
-                    CoconutLayout.spacing_600h,
-                    _titleBox('Pulldown', brightness),
-                    CoconutPulldown(
-                      title: 'TEXT',
-                      isOpen: isPulldownOpen,
-                      onChanged: (value) {
-                        isPulldownOpen = value;
-                        setState(() {});
-                      },
-                    ),
-                    CoconutLayout.spacing_600h,
-                    _titleBox('Textfield', brightness),
-                    Column(
-                      crossAxisAlignment: CrossAxisAlignment.center,
-                      children: [
-                        CoconutTextField(
-                          controller: controller1,
-                          focusNode: focusNode1,
-                          brightness: brightness,
-                          descriptionText: 'Description text',
-                          placeholderText: 'Placeholder text',
-                          errorText: 'Error text',
-                          isError: isVisibleErrorText,
-                          maxLength: maxLength,
-                          prefix: Container(
-                            margin: const EdgeInsets.only(left: 16),
-                            child: Text(
-                              '#',
-                              style: CoconutTypography.body2_14.copyWith(
-                                color: controller1Text.isEmpty
-                                    ? CoconutColors.onGray300(brightness)
-                                    : CoconutColors.onBlack(brightness),
-                              ),
-                            ),
+              return Padding(
+                padding: const EdgeInsets.all(CoconutLayout.defaultPadding),
+                child: Center(
+                  child: Column(
+                    children: [
+                      _titleBox('Chip', brightness),
+                      Wrap(
+                        spacing: 10,
+                        runAlignment: WrapAlignment.center,
+                        runSpacing: 10,
+                        crossAxisAlignment: WrapCrossAlignment.center,
+                        children: [
+                          const CoconutChip(
+                            color: CoconutColors.primary,
+                            label: 'TEXT',
+                            labelColor: CoconutColors.black,
+                            labelSize: 10,
+                            isSelected: true,
                           ),
-                          suffix: GestureDetector(
-                            onTap: () {
-                              controller1.text = '';
-                            },
-                            child: Container(
-                              margin: const EdgeInsets.only(right: 13),
-                              child: SvgPicture.asset(
-                                'assets/svg/textfield_clear.svg',
-                                width: 16,
-                                height: 16,
-                                colorFilter: ColorFilter.mode(
-                                  controller1Text.isEmpty
-                                      ? CoconutColors.onGray300(brightness)
-                                      : controller1Text.runes.length == 10
-                                          ? CoconutColors.red
-                                          : CoconutColors.onBlack(brightness),
-                                  BlendMode.srcIn,
-                                ),
-                              ),
-                            ),
+                          CoconutChip(
+                            color: CoconutColors.onGray150(brightness),
+                            label: 'TEXT',
+                            labelColor: CoconutColors.onBlack(brightness),
+                            labelSize: 10,
+                            isSelected: true,
                           ),
-                          onChanged: (text) {
-                            controller1Text = text;
-                            isVisibleErrorText = text.runes.length == maxLength;
-                            setState(() {});
-                          },
-                        ),
-                        const SizedBox(height: 10),
-                        CoconutTextField(
-                          controller: controller2,
-                          focusNode: focusNode2,
-                          brightness: brightness,
-                          maxLines: 5,
-                          descriptionText: 'Description text',
-                          placeholderText: 'Placeholder text',
-                          onChanged: (text) {},
-                        ),
-                        const SizedBox(height: 10),
-                        CoconutTextField(
-                          controller: controller3,
-                          focusNode: focusNode3,
-                          brightness: brightness,
-                          placeholderText: 'Placeholder text',
-                          maxLength: 16,
-                          obscureText: obscureText,
-                          suffix: GestureDetector(
-                            onTap: () {
-                              obscureText = !obscureText;
+                          CoconutChip(
+                            color: Colors.transparent,
+                            label: 'TEXT3',
+                            labelColor: CoconutColors.onBlack(brightness),
+                            labelSize: 10,
+                            borderColor: CoconutColors.onBlack(brightness),
+                            isSelected: true,
+                          ),
+                          const CoconutChip(
+                            color: CoconutColors.cyan,
+                            padding: EdgeInsets.symmetric(vertical: 2, horizontal: 8),
+                            isRectangle: true,
+                            label: 'TESTNET',
+                            labelColor: CoconutColors.white,
+                            labelSize: 10,
+                            isSelected: true,
+                          ),
+                          CoconutChip(
+                            color: CoconutColors.colorPalette.first,
+                            padding: const EdgeInsets.symmetric(vertical: 2, horizontal: 8),
+                            label: 'isSelected null',
+                            labelColor: CoconutColors.colorPalette.first,
+                            labelSize: 12,
+                            hasOpacity: true,
+                          ),
+                          CoconutChip(
+                            color: CoconutColors.colorPalette.last,
+                            padding: const EdgeInsets.symmetric(vertical: 2, horizontal: 8),
+                            label: 'Selected',
+                            labelColor: CoconutColors.colorPalette.last,
+                            labelSize: 10,
+                            hasOpacity: true,
+                            isSelected: true,
+                          ),
+                          CoconutChip(
+                            color: CoconutColors.colorPalette.last,
+                            padding: const EdgeInsets.symmetric(vertical: 2, horizontal: 8),
+                            label: 'Unselected',
+                            labelColor: CoconutColors.colorPalette.last,
+                            labelSize: 10,
+                            hasOpacity: true,
+                            isSelected: false,
+                          )
+                        ],
+                      ),
+                      CoconutLayout.spacing_600h,
+                      _titleBox('Tag Chip', brightness),
+                      Wrap(
+                        spacing: 10,
+                        runAlignment: WrapAlignment.center,
+                        runSpacing: 10,
+                        crossAxisAlignment: WrapCrossAlignment.center,
+                        children: [
+                          const CoconutTagChip(
+                            tag: 'TEXT',
+                            color: CoconutColors.red,
+                            isRectangle: true,
+                          ),
+                          CoconutTagChip(
+                            tag: 'TEXT',
+                            color: CoconutColors.red,
+                            status: chipStatus,
+                            onTap: (value) {
+                              if (chipStatus == CoconutChipStatus.unselected) {
+                                chipStatus = CoconutChipStatus.selected;
+                              } else {
+                                chipStatus = CoconutChipStatus.unselected;
+                              }
                               setState(() {});
                             },
-                            child: Container(
-                              margin: const EdgeInsets.only(right: 13),
-                              child: SvgPicture.asset(
-                                'assets/svg/textfield_view.svg',
-                                width: 16,
-                                height: 16,
-                                colorFilter: ColorFilter.mode(
-                                  controller3Text.isEmpty
+                          ),
+                        ],
+                      ),
+                      CoconutLayout.spacing_600h,
+                      _titleBox('Checkbox', brightness),
+                      Row(
+                        mainAxisAlignment: MainAxisAlignment.center,
+                        children: [
+                          CoconutCheckbox(
+                            isSelected: isCheckbox1Selected,
+                            onChanged: (value) {
+                              isCheckbox1Selected = value;
+                              setState(() {});
+                            },
+                          ),
+                          const SizedBox(width: 10),
+                          CoconutCheckbox(
+                            isSelected: isCheckbox2Selected,
+                            color: CoconutColors.primary,
+                            onChanged: (value) {
+                              isCheckbox2Selected = value;
+                              setState(() {});
+                            },
+                          ),
+                        ],
+                      ),
+                      CoconutLayout.spacing_600h,
+                      _titleBox('Switch', brightness),
+                      Row(
+                        mainAxisAlignment: MainAxisAlignment.center,
+                        children: [
+                          CoconutSwitch(
+                            isOn: isSwitch1On,
+                            onChanged: (value) {
+                              isSwitch1On = value;
+                              setState(() {});
+                            },
+                          ),
+                          const SizedBox(width: 10),
+                          CoconutSwitch(
+                            isOn: isSwitch2On,
+                            activeColor: CoconutColors.primary,
+                            thumbColor: CoconutColors.white,
+                            onChanged: (value) {
+                              isSwitch2On = value;
+                              setState(() {});
+                            },
+                          ),
+                        ],
+                      ),
+                      CoconutLayout.spacing_600h,
+                      _titleBox('Stepper', brightness),
+                      CoconutStepper(
+                        maxCount: 3,
+                        onCount: (count) {},
+                      ),
+                      CoconutLayout.spacing_600h,
+                      _titleBox('Pulldown', brightness),
+                      CoconutPulldown(
+                        title: 'TEXT',
+                        isOpen: isPulldownOpen,
+                        onChanged: (value) {
+                          isPulldownOpen = value;
+                          setState(() {});
+                        },
+                      ),
+                      CoconutLayout.spacing_600h,
+                      _titleBox('Textfield', brightness),
+                      Column(
+                        crossAxisAlignment: CrossAxisAlignment.center,
+                        children: [
+                          CoconutTextField(
+                            controller: controller1,
+                            focusNode: focusNode1,
+                            brightness: brightness,
+                            descriptionText: 'Description text',
+                            placeholderText: 'Placeholder text',
+                            errorText: 'Error text',
+                            isError: isVisibleErrorText,
+                            maxLength: maxLength,
+                            prefix: Container(
+                              margin: const EdgeInsets.only(left: 16),
+                              child: Text(
+                                '#',
+                                style: CoconutTypography.body2_14.copyWith(
+                                  color: controller1Text.isEmpty
                                       ? CoconutColors.onGray300(brightness)
                                       : CoconutColors.onBlack(brightness),
-                                  BlendMode.srcIn,
                                 ),
                               ),
                             ),
+                            suffix: GestureDetector(
+                              onTap: () {
+                                controller1.text = '';
+                              },
+                              child: Container(
+                                margin: const EdgeInsets.only(right: 13),
+                                child: SvgPicture.asset(
+                                  'assets/svg/textfield_clear.svg',
+                                  width: 16,
+                                  height: 16,
+                                  colorFilter: ColorFilter.mode(
+                                    controller1Text.isEmpty
+                                        ? CoconutColors.onGray300(brightness)
+                                        : controller1Text.runes.length == 10
+                                            ? CoconutColors.red
+                                            : CoconutColors.onBlack(brightness),
+                                    BlendMode.srcIn,
+                                  ),
+                                ),
+                              ),
+                            ),
+                            onChanged: (text) {
+                              controller1Text = text;
+                              isVisibleErrorText = text.runes.length == maxLength;
+                              setState(() {});
+                            },
                           ),
-                          onChanged: (text) {
-                            controller3Text = text;
-                            setState(() {});
-                          },
-                        ),
-                      ],
-                    ),
-                  ],
+                          const SizedBox(height: 10),
+                          CoconutTextField(
+                            controller: controller2,
+                            focusNode: focusNode2,
+                            brightness: brightness,
+                            maxLines: 5,
+                            descriptionText: 'Description text',
+                            placeholderText: 'Placeholder text',
+                            onChanged: (text) {},
+                          ),
+                          const SizedBox(height: 10),
+                          CoconutTextField(
+                            controller: controller3,
+                            focusNode: focusNode3,
+                            brightness: brightness,
+                            placeholderText: 'Placeholder text',
+                            maxLength: 16,
+                            obscureText: obscureText,
+                            suffix: GestureDetector(
+                              onTap: () {
+                                obscureText = !obscureText;
+                                setState(() {});
+                              },
+                              child: Container(
+                                margin: const EdgeInsets.only(right: 13),
+                                child: SvgPicture.asset(
+                                  'assets/svg/textfield_view.svg',
+                                  width: 16,
+                                  height: 16,
+                                  colorFilter: ColorFilter.mode(
+                                    controller3Text.isEmpty
+                                        ? CoconutColors.onGray300(brightness)
+                                        : CoconutColors.onBlack(brightness),
+                                    BlendMode.srcIn,
+                                  ),
+                                ),
+                              ),
+                            ),
+                            onChanged: (text) {
+                              controller3Text = text;
+                              setState(() {});
+                            },
+                          ),
+                        ],
+                      ),
+                    ],
+                  ),
                 ),
-              ),
-            );
-          },
+              );
+            },
+          ),
         ),
       ),
     );

--- a/example/lib/screens/overlays.dart
+++ b/example/lib/screens/overlays.dart
@@ -12,24 +12,42 @@ class OverlaysScreen extends StatefulWidget {
 }
 
 class _OverlaysScreenState extends State<OverlaysScreen> {
-  List<String> pulldownButtons = [
-    'Pulldown1',
-    'Pulldown2',
-    'Pulldown3',
-    'Pulldown4',
-    'Pulldown5'
+  List<CoconutPulldownMenuEntry> pulldownMenuList = [
+    CoconutPulldownMenuGroup(
+      groupTitle: 'Group Title',
+      items: [
+        CoconutPulldownMenuItem(title: 'Group Item1'),
+        CoconutPulldownMenuItem(title: 'Group Item2'),
+        CoconutPulldownMenuItem(title: 'Group Item3'),
+      ],
+    ),
+    CoconutPulldownMenuItem(title: 'Pulldown1'),
+    CoconutPulldownMenuItem(title: 'Pulldown2'),
+    CoconutPulldownMenuItem(title: 'Pulldown3'),
+    CoconutPulldownMenuItem(title: 'Pulldown4'),
+    CoconutPulldownMenuItem(title: 'Pulldown5'),
   ];
   int selectedPulldownIndex = 0;
+  String selectedPulldownTitle = 'Group Item1';
   bool isPulldownOpen = false;
 
-  List<String> pulldownButtons2 = [
-    'Pulldown1',
-    'Pulldown2',
-    'Pulldown3',
-    'Pulldown4',
-    'Pulldown5'
+  List<CoconutPulldownMenuEntry> pulldownMenuList2 = [
+    CoconutPulldownMenuGroup(
+      groupTitle: 'Group Title',
+      items: [
+        CoconutPulldownMenuItem(title: 'Group Item1'),
+        CoconutPulldownMenuItem(title: 'Group Item2'),
+        CoconutPulldownMenuItem(title: 'Group Item3'),
+      ],
+    ),
+    CoconutPulldownMenuItem(title: 'Pulldown1'),
+    CoconutPulldownMenuItem(title: 'Pulldown2'),
+    CoconutPulldownMenuItem(title: 'Pulldown3'),
+    CoconutPulldownMenuItem(title: 'Pulldown4'),
+    CoconutPulldownMenuItem(title: 'Pulldown5'),
   ];
   int selectedPulldownIndex2 = 0;
+  String selectedPulldownTitle2 = 'Group Item1';
   bool isPulldownOpen2 = false;
   bool isClosableTooltipVisible = true;
   bool isLeftPlacementTooltipVisible = true;
@@ -46,8 +64,7 @@ class _OverlaysScreenState extends State<OverlaysScreen> {
           child: Consumer<ThemeProvider>(
             builder: (context, themeProvider, child) {
               final isDarkMode = themeProvider.themeMode == ThemeMode.dark;
-              final brightness =
-                  isDarkMode ? Brightness.dark : Brightness.light;
+              final brightness = isDarkMode ? Brightness.dark : Brightness.light;
 
               return Padding(
                 padding: const EdgeInsets.only(
@@ -92,8 +109,7 @@ class _OverlaysScreenState extends State<OverlaysScreen> {
     );
   }
 
-  Widget _buildBottomSheetExampleList(
-      Brightness brightness, BuildContext context) {
+  Widget _buildBottomSheetExampleList(Brightness brightness, BuildContext context) {
     return _box(
       'BottomSheet',
       brightness,
@@ -336,7 +352,7 @@ class _OverlaysScreenState extends State<OverlaysScreen> {
       brightness,
       [
         CoconutPulldown(
-          title: pulldownButtons[selectedPulldownIndex],
+          title: selectedPulldownTitle,
           isOpen: isPulldownOpen,
           fontSize: 12,
           onChanged: (value) {
@@ -350,10 +366,13 @@ class _OverlaysScreenState extends State<OverlaysScreen> {
           child: Container(
             margin: const EdgeInsets.symmetric(vertical: 12),
             child: CoconutPulldownMenu(
-              buttons: pulldownButtons,
+              entries: pulldownMenuList,
               selectedIndex: selectedPulldownIndex,
-              onTap: (index) {
+              thickDividerIndexList: const [2],
+              thickDividerHeight: 6,
+              onSelected: (index, title) {
                 selectedPulldownIndex = index;
+                selectedPulldownTitle = title;
                 isPulldownOpen = false;
                 isPulldownOpen2 = false;
                 setState(() {});
@@ -362,7 +381,7 @@ class _OverlaysScreenState extends State<OverlaysScreen> {
           ),
         ),
         CoconutPulldown(
-          title: pulldownButtons2[selectedPulldownIndex2],
+          title: selectedPulldownTitle2,
           isOpen: isPulldownOpen2,
           onChanged: (value) {
             isPulldownOpen = false;
@@ -375,11 +394,12 @@ class _OverlaysScreenState extends State<OverlaysScreen> {
           child: Container(
             margin: const EdgeInsets.symmetric(vertical: 12),
             child: CoconutPulldownMenu(
-              buttons: pulldownButtons2,
+              entries: pulldownMenuList2,
               dividerHeight: 3,
               dividerColor: CoconutColors.white,
-              onTap: (index) {
+              onSelected: (index, title) {
                 selectedPulldownIndex2 = index;
+                selectedPulldownTitle2 = title;
                 isPulldownOpen = false;
                 isPulldownOpen2 = false;
                 setState(() {});
@@ -414,8 +434,7 @@ class _OverlaysScreenState extends State<OverlaysScreen> {
           onTap: () {
             CoconutToast.showToast(
               context: context,
-              text:
-                  'Long text text text text text text text text text text text text text',
+              text: 'Long text text text text text text text text text text text text text',
             );
           },
         ),
@@ -439,8 +458,7 @@ class _OverlaysScreenState extends State<OverlaysScreen> {
             CoconutToast.showToast(
               context: context,
               isVisibleIcon: true,
-              text:
-                  'Long text text text text text text text text text text text text text',
+              text: 'Long text text text text text text text text text text text text text',
             );
           },
         ),
@@ -465,8 +483,7 @@ class _OverlaysScreenState extends State<OverlaysScreen> {
               brightness: brightness,
               context: context,
               seconds: 3,
-              text:
-                  'Long text text text text text text text text text text text text text',
+              text: 'Long text text text text text text text text text text text text text',
             );
           },
         ),

--- a/lib/src/components/inputs/textfield.dart
+++ b/lib/src/components/inputs/textfield.dart
@@ -212,13 +212,20 @@ class _CoconutTextFieldState extends State<CoconutTextField> {
   late Color _cursorColor;
   late Color _backgroundColor;
 
+  final GlobalKey _prefixGlobalKey = GlobalKey();
+  Size _prefixSize = const Size(0, 0);
+  Offset _prefixPosition = Offset.zero;
+
   String _text = '';
+  String _placeholderText = '';
   bool _isFocus = false;
 
   /// Listens to focus changes and updates the UI accordingly.
   void _focusNodeListener() {
     _isFocus = widget.focusNode.hasFocus;
-    setState(() {});
+    setState(() {
+      _placeholderText = (_isFocus || _text.isNotEmpty) ? '' : (widget.placeholderText ?? '');
+    });
   }
 
   void _updateData() {
@@ -232,9 +239,18 @@ class _CoconutTextFieldState extends State<CoconutTextField> {
 
   @override
   void initState() {
+    super.initState();
+    _placeholderText = widget.prefix == null ? widget.placeholderText ?? '' : '';
     widget.focusNode.addListener(_focusNodeListener);
     _updateData();
-    super.initState();
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (_prefixGlobalKey.currentContext != null) {
+        final prefixRenderBox = _prefixGlobalKey.currentContext?.findRenderObject() as RenderBox;
+        _prefixSize = prefixRenderBox.size;
+        _prefixPosition = prefixRenderBox.localToGlobal(Offset.zero);
+        _placeholderText = widget.placeholderText ?? '';
+      }
+    });
   }
 
   @override
@@ -272,47 +288,64 @@ class _CoconutTextFieldState extends State<CoconutTextField> {
             borderRadius: BorderRadius.circular(12),
             color: _backgroundColor,
           ),
-          child: CupertinoTextField(
-            focusNode: widget.focusNode,
-            controller: widget.controller,
-            inputFormatters: widget.textInputFormatter,
-            obscureText: widget.obscureText,
-            textAlign: widget.textAlign ?? TextAlign.start,
-            padding:
-                widget.padding ?? EdgeInsets.fromLTRB(widget.prefix != null ? 0 : 16, 20, 16, 20),
-            style: CoconutTypography.body2_14.copyWith(
-              color: _activeColor,
-              fontSize: widget.fontSize,
-              fontFamily: widget.fontFamily,
-            ),
-            placeholder: widget.placeholderText,
-            placeholderStyle: CoconutTypography.body2_14.copyWith(
-              color: _placeholderColor,
-              height: 1,
-              fontSize: widget.fontSize,
-            ),
-            cursorColor: _cursorColor,
-            decoration: const BoxDecoration(
-              color: Colors.transparent,
-            ),
-            maxLength: widget.maxLength,
-            maxLines: widget.obscureText ? 1 : widget.maxLines,
-            prefix: widget.prefix,
-            suffix: widget.suffix,
-            keyboardType: widget.textInputType,
-            textInputAction: widget.textInputAction,
-            onChanged: (text) {
-              if (widget.maxLength != null) {
-                if (text.runes.length > widget.maxLength!) {
-                  text = String.fromCharCodes(text.runes.take(widget.maxLength!));
-                  widget.controller.text = text;
-                }
-              }
+          child: Stack(
+            children: [
+              CupertinoTextField(
+                focusNode: widget.focusNode,
+                controller: widget.controller,
+                inputFormatters: widget.textInputFormatter,
+                obscureText: widget.obscureText,
+                textAlign: widget.textAlign ?? TextAlign.start,
+                padding: widget.padding ??
+                    EdgeInsets.fromLTRB(widget.prefix != null ? 0 : 16, 20, 16, 20),
+                style: CoconutTypography.body2_14.copyWith(
+                  color: _activeColor,
+                  fontSize: widget.fontSize,
+                  fontFamily: widget.fontFamily,
+                ),
+                cursorColor: _cursorColor,
+                decoration: const BoxDecoration(
+                  color: Colors.transparent,
+                ),
+                maxLength: widget.maxLength,
+                maxLines: widget.obscureText ? 1 : widget.maxLines,
+                prefix: Container(
+                  key: _prefixGlobalKey,
+                  child: widget.prefix,
+                ),
+                suffix: widget.suffix,
+                keyboardType: widget.textInputType,
+                textInputAction: widget.textInputAction,
+                textAlignVertical: TextAlignVertical.bottom,
+                onChanged: (text) {
+                  if (widget.maxLength != null) {
+                    if (text.runes.length > widget.maxLength!) {
+                      text = String.fromCharCodes(text.runes.take(widget.maxLength!));
+                      widget.controller.text = text;
+                    }
+                  }
 
-              _text = text;
-              setState(() {});
-              widget.onChanged(_text);
-            },
+                  _text = text;
+                  setState(() {});
+                  widget.onChanged(_text);
+                },
+              ),
+              Container(
+                height: widget.prefix != null ? _prefixSize.height : null,
+                margin: widget.prefix == null
+                    ? widget.padding ?? const EdgeInsets.fromLTRB(16, 20, 16, 20)
+                    : EdgeInsets.only(left: _prefixSize.width, top: widget.padding?.top ?? 20),
+                alignment: Alignment.centerLeft,
+                child: Text(
+                  _placeholderText,
+                  style: CoconutTypography.body2_14.copyWith(
+                    color: _placeholderColor,
+                    height: 1,
+                    fontSize: widget.fontSize,
+                  ),
+                ),
+              )
+            ],
           ),
         ),
         Padding(

--- a/lib/src/components/overlays/pulldown_menu.dart
+++ b/lib/src/components/overlays/pulldown_menu.dart
@@ -76,7 +76,7 @@ class CoconutPulldownMenu extends StatelessWidget {
   /// The margin around the dropdown menu (default: `EdgeInsets.zero`).
   final EdgeInsets margin;
 
-  /// The padding inside each button (default: `EdgeInsets.symmetric(horizontal: 16)`).
+  /// The padding inside each button (default: `EdgeInsets.symmetric(horizontal: 20)`).
   final EdgeInsets? buttonPadding;
 
   /// The height of each dropdown button (default: `44.0`).
@@ -195,7 +195,7 @@ class CoconutPulldownMenu extends StatelessWidget {
                   children: [
                     Container(
                       padding: groupTitlePadding ??
-                          const EdgeInsets.symmetric(horizontal: 16, vertical: 4),
+                          const EdgeInsets.symmetric(horizontal: 20, vertical: 4),
                       alignment: Alignment.centerLeft,
                       decoration: BoxDecoration(
                         borderRadius: index == 0
@@ -289,7 +289,7 @@ class CoconutPulldownMenu extends StatelessWidget {
             highlightColor: Colors.transparent,
             child: Container(
               height: buttonHeight,
-              padding: buttonPadding ?? const EdgeInsets.symmetric(horizontal: 16),
+              padding: buttonPadding ?? const EdgeInsets.symmetric(horizontal: 20),
               alignment: Alignment.centerLeft,
               decoration: BoxDecoration(
                 borderRadius: _getBorderRadius(

--- a/lib/src/components/overlays/pulldown_menu.dart
+++ b/lib/src/components/overlays/pulldown_menu.dart
@@ -249,41 +249,38 @@ class CoconutPulldownMenu extends StatelessWidget {
     double borderRadius,
     Brightness brightness,
   ) {
-    debugPrint('index: $index, flaatened: $flattenedEntryListLenght');
+    final isBottomRounded = index ==
+        entries
+                .map((e) => e is CoconutPulldownMenuItem
+                    ? 1
+                    : e is CoconutPulldownMenuGroup
+                        ? e.items.length
+                        : 0)
+                .fold(0, (a, b) => a + b) -
+            1;
+
+    final isTopRounded = index == 0 && entries[index] is! CoconutPulldownMenuGroup;
     return Column(
       children: [
         Material(
           color: backgroundColor ?? CoconutColors.onGray100(brightness),
           shape: RoundedRectangleBorder(
             borderRadius: _getBorderRadius(
-                  index,
-                  entries
-                      .map((e) => e is CoconutPulldownMenuItem
-                          ? 1
-                          : e is CoconutPulldownMenuGroup
-                              ? e.items.length
-                              : 0)
-                      .fold(0, (a, b) => a + b),
-                  borderRadius,
-                  brightness,
-                ) ??
-                BorderRadius.zero,
+              borderRadius,
+              brightness,
+              isBottomRounded: isBottomRounded,
+              isTopRounded: isTopRounded,
+            ),
           ),
           child: InkWell(
             onTap: () {
               onSelected.call(index, title);
             },
             borderRadius: _getBorderRadius(
-              index,
-              entries
-                  .map((e) => e is CoconutPulldownMenuItem
-                      ? 1
-                      : e is CoconutPulldownMenuGroup
-                          ? e.items.length
-                          : 0)
-                  .fold(0, (a, b) => a + b),
               borderRadius,
               brightness,
+              isBottomRounded: isBottomRounded,
+              isTopRounded: isTopRounded,
             ),
             splashColor: splashColor ?? CoconutColors.onGray200(brightness),
             highlightColor: Colors.transparent,
@@ -293,10 +290,10 @@ class CoconutPulldownMenu extends StatelessWidget {
               alignment: Alignment.centerLeft,
               decoration: BoxDecoration(
                 borderRadius: _getBorderRadius(
-                  index,
-                  entries.length,
                   borderRadius,
                   brightness,
+                  isBottomRounded: isBottomRounded,
+                  isTopRounded: isTopRounded,
                 ),
               ),
               child: Row(
@@ -345,15 +342,14 @@ class CoconutPulldownMenu extends StatelessWidget {
   }
 
   /// Determines the border radius for the first and last items.
-  BorderRadius? _getBorderRadius(
-      int index, int length, double borderRadius, Brightness brightness) {
-    if (index == length - 1) {
-      return BorderRadius.only(
-        bottomLeft: Radius.circular(borderRadius),
-        bottomRight: Radius.circular(borderRadius),
-      );
-    }
-    return null; // No border radius for middle items
+  BorderRadius _getBorderRadius(double borderRadius, Brightness brightness,
+      {bool isTopRounded = false, bool isBottomRounded = false}) {
+    return BorderRadius.only(
+      topLeft: isTopRounded ? Radius.circular(borderRadius) : const Radius.circular(0),
+      topRight: isTopRounded ? Radius.circular(borderRadius) : const Radius.circular(0),
+      bottomLeft: isBottomRounded ? Radius.circular(borderRadius) : const Radius.circular(0),
+      bottomRight: isBottomRounded ? Radius.circular(borderRadius) : const Radius.circular(0),
+    );
   }
 }
 


### PR DESCRIPTION
### 변경사항
**CoconutPulldown**
- (-) buttons 속성과 onTap 콜백은 더 이상 사용되지 않으며 deprecated 처리됨
   - 1.0.0 버전부터 완전히 제거될 예정
- (+) 새로운 구조: entries 기반의 구조로 대체
   - buttons: List<String> → entries: List<CoconutPulldownMenuEntry>
   - 이 구조는 개별 아이템(CoconutPulldownMenuItem)뿐 아니라 그룹(CoconutPulldownMenuGroup)까지 지원
- (+) CoconutPulldownMenuGroup 도입
   - groupTitle 과 하위 items 리스트를 포함하여 그룹화된 항목을 표시할 수 있음
   - groupTitleStyle, groupTitlePadding, groupTitleColor로 그룹타이틀에 속성을 따로 설정할 수 있음
- (+) 콜백 방식 변경
   - onTap(int index) → onSelected(int index, String title)로 변경되어 선택된 항목의 제목까지 함께 전달

<table>
  <tr>
    <td valign="top">
      <img 
        src="https://github.com/user-attachments/assets/2d4c499f-000f-49da-aa55-53782fffd4d9"
        width="300"
      >
<img 
        src="https://github.com/user-attachments/assets/a8a4efee-355a-4d5d-af20-9de47f1b3fa6"
        width="300"
      >
    </td>
  </tr>
</table>

**CoconutTextField**
- (+) placeholderText의 위치가 textField의 중앙에 표시되지 않고 textField의 상단에 표시되도록 변경
- (+) textField에 focus가 되면 placeHolder는 보이지 않도록 변경

<table>
  <tr>
    <td valign="top">
      <img 
        src="https://github.com/user-attachments/assets/322bbeb8-c667-4908-9e9d-bb9a8d781079"
        width="300"
      >
    </td>
  </tr>
</table>
#17