### PR TITLE
fix(appbar, popup): adjust AppBar height and leading padding, adjust Dialog radius

### DIFF
--- a/lib/src/components/appbar.dart
+++ b/lib/src/components/appbar.dart
@@ -124,17 +124,11 @@ class CoconutAppBar {
               statusBarBrightness: Brightness.light, // 상태바 아이콘 (iOS)
               statusBarIconBrightness: Brightness.dark, // 상태바 아이콘 (Android)
               systemNavigationBarColor: CoconutColors.white, // 하단 네비게이션바 배경
-              systemNavigationBarIconBrightness:
-                  Brightness.dark, // 하단 네비게이션바 아이콘
+              systemNavigationBarIconBrightness: Brightness.dark, // 하단 네비게이션바 아이콘
             )
           : SystemUiOverlayStyle.light,
       key: entireWidgetKey,
-      toolbarHeight: height ??
-          (isBottom
-              ? 50
-              : Platform.isIOS
-                  ? 44
-                  : 56),
+      toolbarHeight: height ?? (isBottom ? 60 : 56),
       title: widget,
       scrolledUnderElevation: 0,
       centerTitle: true,
@@ -142,26 +136,31 @@ class CoconutAppBar {
       backgroundColor: backgroundColor ?? Colors.transparent,
       leading: isLeadingVisible
           ? Navigator.canPop(context)
-              ? Row(
+              ? Column(
                   children: [
-                    CoconutLayout.spacing_200w,
-                    IconButton(
-                      icon: SvgPicture.asset(
-                        isBottom && !isBackButton
-                            ? 'packages/coconut_design_system/assets/svg/close.svg'
-                            : 'packages/coconut_design_system/assets/svg/arrow-back.svg',
-                        colorFilter:
-                            ColorFilter.mode(CoconutColors.onPrimary(brightness), BlendMode.srcIn),
-                        width: 24,
-                        height: 24,
-                      ),
-                      onPressed: () {
-                        if (onBackPressed != null) {
-                          onBackPressed();
-                        } else {
-                          Navigator.pop(context);
-                        }
-                      },
+                    CoconutLayout.spacing_100h,
+                    Row(
+                      children: [
+                        CoconutLayout.spacing_100w,
+                        IconButton(
+                          icon: SvgPicture.asset(
+                            isBottom && !isBackButton
+                                ? 'packages/coconut_design_system/assets/svg/close.svg'
+                                : 'packages/coconut_design_system/assets/svg/arrow-back.svg',
+                            colorFilter: ColorFilter.mode(
+                                CoconutColors.onPrimary(brightness), BlendMode.srcIn),
+                            width: 24,
+                            height: 24,
+                          ),
+                          onPressed: () {
+                            if (onBackPressed != null) {
+                              onBackPressed();
+                            } else {
+                              Navigator.pop(context);
+                            }
+                          },
+                        ),
+                      ],
                     ),
                   ],
                 )
@@ -406,32 +405,37 @@ class CoconutAppBar {
       scrolledUnderElevation: 0,
       toolbarHeight: height ??
           (isBottom
-              ? 50
+              ? 60
               : Platform.isIOS
                   ? 44
                   : 56),
       backgroundColor: backgroundColor ?? Colors.transparent,
       leading: Navigator.canPop(context)
-          ? Row(
+          ? Column(
               children: [
-                CoconutLayout.spacing_200w,
-                IconButton(
-                  icon: SvgPicture.asset(
-                    isBottom
-                        ? 'packages/coconut_design_system/assets/svg/close.svg'
-                        : 'packages/coconut_design_system/assets/svg/arrow-back.svg',
-                    colorFilter:
-                        ColorFilter.mode(CoconutColors.onPrimary(brightness), BlendMode.srcIn),
-                    width: 24,
-                    height: 24,
-                  ),
-                  onPressed: () {
-                    if (onBackPressed != null) {
-                      onBackPressed();
-                    } else {
-                      Navigator.pop(context);
-                    }
-                  },
+                CoconutLayout.spacing_100h,
+                Row(
+                  children: [
+                    CoconutLayout.spacing_100w,
+                    IconButton(
+                      icon: SvgPicture.asset(
+                        isBottom
+                            ? 'packages/coconut_design_system/assets/svg/close.svg'
+                            : 'packages/coconut_design_system/assets/svg/arrow-back.svg',
+                        colorFilter:
+                            ColorFilter.mode(CoconutColors.onPrimary(brightness), BlendMode.srcIn),
+                        width: 24,
+                        height: 24,
+                      ),
+                      onPressed: () {
+                        if (onBackPressed != null) {
+                          onBackPressed();
+                        } else {
+                          Navigator.pop(context);
+                        }
+                      },
+                    ),
+                  ],
                 ),
               ],
             )

--- a/lib/src/components/overlays/popup.dart
+++ b/lib/src/components/overlays/popup.dart
@@ -80,6 +80,9 @@ class CoconutPopup extends StatefulWidget {
   /// The padding around the description content.
   final EdgeInsets? descriptionPadding;
 
+  /// The padding around the whole dialog.
+  final EdgeInsets? insetPadding;
+
   /// Creates an instance of `CoconutPopup`.
   const CoconutPopup({
     super.key,
@@ -101,6 +104,7 @@ class CoconutPopup extends StatefulWidget {
     this.rightButtonTextStyle,
     this.titlePadding,
     this.descriptionPadding,
+    this.insetPadding,
   });
 
   @override
@@ -115,6 +119,11 @@ class _CoconutPopupState extends State<CoconutPopup> {
     Brightness brightness = Theme.of(context).brightness;
 
     return Dialog(
+      insetPadding: widget.insetPadding,
+      shape: const RoundedRectangleBorder(
+        borderRadius: BorderRadius.all(Radius.circular(16)),
+      ),
+      backgroundColor: Theme.of(context).dialogBackgroundColor,
       child: ClipRRect(
         borderRadius: const BorderRadius.all(Radius.circular(16)),
         child: Container(
@@ -128,15 +137,13 @@ class _CoconutPopupState extends State<CoconutPopup> {
               children: [
                 /// Title Section
                 Container(
-                  padding: widget.titlePadding ??
-                      const EdgeInsets.only(top: 24, bottom: 12),
+                  padding: widget.titlePadding ?? const EdgeInsets.only(top: 24, bottom: 12),
                   child: Text(
                     widget.title,
-                    style: widget.titleTextStyle?.setColor(widget.titleColor ??
-                            CoconutColors.onGray900(brightness)) ??
+                    style: widget.titleTextStyle
+                            ?.setColor(widget.titleColor ?? CoconutColors.onGray900(brightness)) ??
                         CoconutTypography.body1_16_Bold.setColor(
-                          widget.titleColor ??
-                              CoconutColors.onGray900(brightness),
+                          widget.titleColor ?? CoconutColors.onGray900(brightness),
                         ),
                   ),
                 ),
@@ -145,19 +152,15 @@ class _CoconutPopupState extends State<CoconutPopup> {
                 Container(
                   alignment: Alignment.topCenter,
                   padding: widget.descriptionPadding ??
-                      const EdgeInsets.only(
-                          left: 24, right: 24, top: 12, bottom: 12),
+                      const EdgeInsets.only(left: 24, right: 24, top: 12, bottom: 12),
                   constraints: const BoxConstraints(minHeight: 66),
                   child: Text(
                     widget.description,
-                    textAlign:
-                        widget.centerDescription ? TextAlign.center : null,
+                    textAlign: widget.centerDescription ? TextAlign.center : null,
                     style: widget.descriptionTextStyle?.setColor(
-                            widget.descriptionColor ??
-                                CoconutColors.onGray800(brightness)) ??
+                            widget.descriptionColor ?? CoconutColors.onGray800(brightness)) ??
                         CoconutTypography.body1_16.setColor(
-                          widget.descriptionColor ??
-                              CoconutColors.onGray800(brightness),
+                          widget.descriptionColor ?? CoconutColors.onGray800(brightness),
                         ),
                   ),
                 ),
@@ -187,18 +190,15 @@ class _CoconutPopupState extends State<CoconutPopup> {
                           child: Container(
                             padding: const EdgeInsets.only(top: 16, bottom: 16),
                             color: _isLeftButtonPressing
-                                ? CoconutColors.onPrimary(brightness)
-                                    .withOpacity(0.2)
+                                ? CoconutColors.onPrimary(brightness).withOpacity(0.2)
                                 : Colors.transparent,
                             alignment: Alignment.center,
                             child: Text(
                               widget.leftButtonText,
-                              style: widget.leftButtonTextStyle?.setColor(widget
-                                          .leftButtonColor ??
+                              style: widget.leftButtonTextStyle?.setColor(widget.leftButtonColor ??
                                       CoconutColors.onGray900(brightness)) ??
                                   CoconutTypography.body1_16.setColor(
-                                    widget.leftButtonColor ??
-                                        CoconutColors.onGray900(brightness),
+                                    widget.leftButtonColor ?? CoconutColors.onGray900(brightness),
                                   ),
                             ),
                           ),
@@ -226,18 +226,15 @@ class _CoconutPopupState extends State<CoconutPopup> {
                         child: Container(
                           padding: const EdgeInsets.only(top: 16, bottom: 16),
                           color: _isRightButtonPressing
-                              ? CoconutColors.onPrimary(brightness)
-                                  .withOpacity(0.2)
+                              ? CoconutColors.onPrimary(brightness).withOpacity(0.2)
                               : Colors.transparent,
                           alignment: Alignment.center,
                           child: Text(
                             widget.rightButtonText,
-                            style: widget.rightButtonTextStyle?.setColor(
-                                    widget.rightButtonColor ??
-                                        CoconutColors.onGray900(brightness)) ??
+                            style: widget.rightButtonTextStyle?.setColor(widget.rightButtonColor ??
+                                    CoconutColors.onGray900(brightness)) ??
                                 CoconutTypography.body1_16_Bold.setColor(
-                                  widget.rightButtonColor ??
-                                      CoconutColors.onGray900(brightness),
+                                  widget.rightButtonColor ?? CoconutColors.onGray900(brightness),
                                 ),
                           ),
                         ),


### PR DESCRIPTION
1. CoconutAppbar.buildWithNext - leading아이콘의 horizontal, vertical padding이 동일하게 설정되도록 수정
2. Dialog에서 ClipRRect의 외부 영역의 Radius가 달라 일부 영역이 비치는 버그 수정, insetPadding 파라미터를 추가함으로써 호출하는 화면에서 Dialog 자체에 패딩을 지정할 수 있도록 수정