### PR TITLE
[24] adjust icon alignment based on richText line count

### DIFF
--- a/lib/src/components/overlays/toast.dart
+++ b/lib/src/components/overlays/toast.dart
@@ -238,41 +238,58 @@ class _CoconutToastWidgetState extends State<CoconutToastWidget>
                 width: 1,
               ),
             ),
-            child: Row(
-              crossAxisAlignment: CrossAxisAlignment.start,
-              children: [
-                if (widget.isVisibleIcon) ...{
-                  Padding(
-                    padding: EdgeInsets.only(right: widget.iconRightPadding),
-                    child: SvgPicture.asset(
-                      widget.iconPath ??
-                          'packages/coconut_design_system/assets/svg/info_circle.svg',
-                      height: widget.iconSize,
-                      colorFilter: ColorFilter.mode(
-                        widget.borderColor ?? CoconutColors.onGray100(widget.brightness),
-                        BlendMode.srcIn,
+            child: LayoutBuilder(
+              builder: (context, constraints) {
+                final textPainter = TextPainter(
+                  text: TextSpan(text: widget.text),
+                  maxLines: null,
+                  textDirection: TextDirection.ltr,
+                )..layout(maxWidth: constraints.maxWidth);
+
+                final isMultiline = textPainter.computeLineMetrics().length > 1;
+
+                return Row(
+                  crossAxisAlignment:
+                      isMultiline ? CrossAxisAlignment.start : CrossAxisAlignment.center,
+                  children: [
+                    if (widget.isVisibleIcon) ...{
+                      Padding(
+                        padding: EdgeInsets.only(
+                          right: widget.iconRightPadding,
+                          top: widget.textPadding,
+                          bottom: widget.textPadding,
+                        ),
+                        child: SvgPicture.asset(
+                          widget.iconPath ??
+                              'packages/coconut_design_system/assets/svg/info_circle.svg',
+                          height: widget.iconSize,
+                          colorFilter: ColorFilter.mode(
+                            widget.borderColor ?? CoconutColors.onGray100(widget.brightness),
+                            BlendMode.srcIn,
+                          ),
+                        ),
+                      ),
+                    } else ...{
+                      SizedBox(
+                        height: widget.iconSize,
+                      ),
+                    },
+                    Flexible(
+                      child: Padding(
+                        padding: EdgeInsets.symmetric(vertical: widget.textPadding),
+                        child: Text(
+                          widget.text,
+                          style: CoconutTypography.body2_14.copyWith(
+                            decoration: TextDecoration.none, // Prevents underlining in debug mode
+                            color: widget.textColor ?? CoconutColors.onGray100(widget.brightness),
+                            fontSize: widget.fontSize,
+                          ),
+                        ),
                       ),
                     ),
-                  ),
-                } else ...{
-                  SizedBox(
-                    height: widget.iconSize,
-                  ),
-                },
-                Flexible(
-                  child: Padding(
-                    padding: EdgeInsets.symmetric(vertical: widget.textPadding),
-                    child: Text(
-                      widget.text,
-                      style: CoconutTypography.body2_14.copyWith(
-                        decoration: TextDecoration.none, // Prevents underlining in debug mode
-                        color: widget.textColor ?? CoconutColors.onGray100(widget.brightness),
-                        fontSize: widget.fontSize,
-                      ),
-                    ),
-                  ),
-                ),
-              ],
+                  ],
+                );
+              },
             ),
           ),
         ),


### PR DESCRIPTION
1. CoconutToast에서 아이콘이 text의 멀티라인 여부에 따라 위치가 설정되도록 수정(싱글라인: center, 멀티라인: top)

#24