### PR TITLE
Feat/coconut option picker

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -1,6 +1,7 @@
 import 'package:coconut_design_system/coconut_design_system.dart';
 import 'package:example/provider/appbar_provider.dart';
 import 'package:example/screens/appbar.dart';
+import 'package:example/screens/animation.dart';
 import 'package:example/screens/button.dart';
 import 'package:example/screens/color.dart';
 import 'package:example/screens/home.dart';
@@ -114,6 +115,11 @@ final GoRouter _router = GoRouter(
       name: 'overlays',
       path: '/overlays',
       builder: (context, state) => const OverlaysScreen(),
+    ),
+    GoRoute(
+      name: 'animation',
+      path: '/animation',
+      builder: (context, state) => const AnimationScreen(),
     ),
   ],
 );

--- a/example/lib/screens/animation.dart
+++ b/example/lib/screens/animation.dart
@@ -1,0 +1,475 @@
+import 'package:coconut_design_system/coconut_design_system.dart';
+import 'package:example/appbar.dart';
+import 'package:example/provider/theme_provider.dart';
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+
+class AnimationScreen extends StatefulWidget {
+  const AnimationScreen({super.key});
+
+  @override
+  State<AnimationScreen> createState() => _AnimationScreenState();
+}
+
+class _AnimationScreenState extends State<AnimationScreen> {
+  final Map<String, int> _playCounts = <String, int>{};
+
+  void _replay(String key) {
+    setState(() {
+      _playCounts[key] = (_playCounts[key] ?? 0) + 1;
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: const MyAppBar(),
+      body: Consumer<ThemeProvider>(
+        builder: (context, themeProvider, child) {
+          final isDarkMode = themeProvider.themeMode == ThemeMode.dark;
+          final brightness = isDarkMode ? Brightness.dark : Brightness.light;
+
+          return SingleChildScrollView(
+            padding: const EdgeInsets.only(
+              left: CoconutLayout.defaultPadding,
+              right: CoconutLayout.defaultPadding,
+              top: Sizes.size30,
+              bottom: Sizes.size60,
+            ),
+            child: Column(
+              children: [
+                _buildAnimationExample(
+                  title: 'Slide Up',
+                  replayKey: 'slide_up',
+                  brightness: brightness,
+                  childBuilder: (key, sample) => CoconutSlideUpAnimation(
+                    key: key,
+                    child: sample,
+                  ),
+                ),
+                _buildAnimationExample(
+                  title: 'Slide Down',
+                  replayKey: 'slide_down',
+                  brightness: brightness,
+                  childBuilder: (key, sample) => CoconutSlideDownAnimation(
+                    key: key,
+                    child: sample,
+                  ),
+                ),
+                _buildAnimationExample(
+                  title: 'Slide Left',
+                  replayKey: 'slide_left',
+                  brightness: brightness,
+                  childBuilder: (key, sample) => CoconutSlideLeftAnimation(
+                    key: key,
+                    child: sample,
+                  ),
+                ),
+                _buildAnimationExample(
+                  title: 'Slide Right',
+                  replayKey: 'slide_right',
+                  brightness: brightness,
+                  childBuilder: (key, sample) => CoconutSlideRightAnimation(
+                    key: key,
+                    child: sample,
+                  ),
+                ),
+                _buildAnimationExample(
+                  title: 'Fade In',
+                  replayKey: 'fade_in',
+                  brightness: brightness,
+                  childBuilder: (key, sample) => CoconutFadeInAnimation(
+                    key: key,
+                    child: sample,
+                  ),
+                ),
+                _buildAnimationExample(
+                  title: 'Fade Out',
+                  replayKey: 'fade_out',
+                  brightness: brightness,
+                  childBuilder: (key, sample) => CoconutFadeOutAnimation(
+                    key: key,
+                    child: sample,
+                  ),
+                ),
+                _buildAnimationExample(
+                  title: 'Scale In',
+                  replayKey: 'scale_in',
+                  brightness: brightness,
+                  childBuilder: (key, sample) => CoconutScaleInAnimation(
+                    key: key,
+                    child: sample,
+                  ),
+                ),
+                _buildAnimationExample(
+                  title: 'Scale Out',
+                  replayKey: 'scale_out',
+                  brightness: brightness,
+                  childBuilder: (key, sample) => CoconutScaleOutAnimation(
+                    key: key,
+                    child: sample,
+                  ),
+                ),
+                _buildAnimationExample(
+                  title: 'Zoom In',
+                  replayKey: 'zoom_in',
+                  brightness: brightness,
+                  childBuilder: (key, sample) => CoconutZoomInAnimation(
+                    key: key,
+                    child: sample,
+                  ),
+                ),
+                _buildAnimationExample(
+                  title: 'Zoom Out',
+                  replayKey: 'zoom_out',
+                  brightness: brightness,
+                  childBuilder: (key, sample) => CoconutZoomOutAnimation(
+                    key: key,
+                    child: sample,
+                  ),
+                ),
+                _buildAnimationExample(
+                  title: 'Bounce In',
+                  replayKey: 'bounce_in',
+                  brightness: brightness,
+                  childBuilder: (key, sample) => CoconutBounceInAnimation(
+                    key: key,
+                    child: sample,
+                  ),
+                ),
+                _buildAnimationExample(
+                  title: 'Bounce Out',
+                  replayKey: 'bounce_out',
+                  brightness: brightness,
+                  childBuilder: (key, sample) => CoconutBounceOutAnimation(
+                    key: key,
+                    child: sample,
+                  ),
+                ),
+                _buildAnimationExample(
+                  title: 'Typewriter',
+                  replayKey: 'typewriter',
+                  brightness: brightness,
+                  childBuilder: (key, sample) => CoconutTypewriterAnimation(
+                    key: key,
+                    text: 'Coconut typewriter animation example',
+                    textStyle: CoconutTypography.body2_14_Bold.setColor(
+                      CoconutColors.onBlack(brightness),
+                    ),
+                    duration: const Duration(milliseconds: 1800),
+                  ),
+                  sampleBuilder: () => _buildTypewriterSample(brightness),
+                ),
+                _buildAnimationExample(
+                  title: 'Character Fade In',
+                  replayKey: 'character_fade_in',
+                  brightness: brightness,
+                  childBuilder: (key, sample) => CoconutCharacterFadeInAnimation(
+                    key: key,
+                    text: 'Characters fade in without shifting layout',
+                    textStyle: CoconutTypography.body2_14_Bold.setColor(
+                      CoconutColors.onBlack(brightness),
+                    ),
+                    duration: const Duration(milliseconds: 1600),
+                  ),
+                ),
+                _buildAnimationExample(
+                  title: 'Character Fade In Slide Down',
+                  replayKey: 'character_fade_in_slide_down',
+                  brightness: brightness,
+                  childBuilder: (key, sample) => CoconutCharacterFadeInAnimation(
+                    key: key,
+                    text: 'Characters fade in with slide down',
+                    textStyle: CoconutTypography.body2_14_Bold.setColor(
+                      CoconutColors.onBlack(brightness),
+                    ),
+                    duration: const Duration(milliseconds: 1600),
+                    slideDirection: CoconutCharacterFadeSlideDirection.slideDown,
+                  ),
+                ),
+                _buildAnimationExample(
+                  title: 'Character Fade In Slide Up',
+                  replayKey: 'character_fade_in_slide_up',
+                  brightness: brightness,
+                  childBuilder: (key, sample) => CoconutCharacterFadeInAnimation(
+                    key: key,
+                    text: 'Characters fade in with slide up',
+                    textStyle: CoconutTypography.body2_14_Bold.setColor(
+                      CoconutColors.onBlack(brightness),
+                    ),
+                    duration: const Duration(milliseconds: 1600),
+                    slideDirection: CoconutCharacterFadeSlideDirection.slideUp,
+                  ),
+                ),
+                _buildAnimationExample(
+                  title: 'Character Fade Out',
+                  replayKey: 'character_fade_out',
+                  brightness: brightness,
+                  childBuilder: (key, sample) => CoconutCharacterFadeOutAnimation(
+                    key: key,
+                    text: 'Characters fade out without shifting layout',
+                    textStyle: CoconutTypography.body2_14_Bold.setColor(
+                      CoconutColors.onBlack(brightness),
+                    ),
+                    duration: const Duration(milliseconds: 1600),
+                  ),
+                ),
+                _buildAnimationExample(
+                  title: 'Character Fade Out Slide Down',
+                  replayKey: 'character_fade_out_slide_down',
+                  brightness: brightness,
+                  childBuilder: (key, sample) => CoconutCharacterFadeOutAnimation(
+                    key: key,
+                    text: 'Characters fade out with slide down',
+                    textStyle: CoconutTypography.body2_14_Bold.setColor(
+                      CoconutColors.onBlack(brightness),
+                    ),
+                    duration: const Duration(milliseconds: 1600),
+                    slideDirection: CoconutCharacterFadeSlideDirection.slideDown,
+                  ),
+                ),
+                _buildAnimationExample(
+                  title: 'Character Fade Out Slide Up',
+                  replayKey: 'character_fade_out_slide_up',
+                  brightness: brightness,
+                  childBuilder: (key, sample) => CoconutCharacterFadeOutAnimation(
+                    key: key,
+                    text: 'Characters fade out with slide up',
+                    textStyle: CoconutTypography.body2_14_Bold.setColor(
+                      CoconutColors.onBlack(brightness),
+                    ),
+                    duration: const Duration(milliseconds: 1600),
+                    slideDirection: CoconutCharacterFadeSlideDirection.slideUp,
+                  ),
+                ),
+                _buildCharacterFadeSequenceExample(brightness),
+              ],
+            ),
+          );
+        },
+      ),
+    );
+  }
+
+  Widget _buildAnimationExample({
+    required String title,
+    required String replayKey,
+    required Brightness brightness,
+    required Widget Function(ValueKey<int> key, Widget sample) childBuilder,
+    Widget Function()? sampleBuilder,
+  }) {
+    final sample = sampleBuilder?.call() ?? _buildSampleCard(brightness, title);
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Text(
+          title,
+          style: CoconutTypography.body1_16_Bold.setColor(
+            CoconutColors.onPrimary(brightness),
+          ),
+        ),
+        CoconutLayout.spacing_300h,
+        Container(
+          width: double.infinity,
+          padding: const EdgeInsets.all(16),
+          decoration: BoxDecoration(
+            color: CoconutColors.onGray100(brightness),
+            borderRadius: BorderRadius.circular(16),
+            border: Border.all(
+              color: CoconutColors.onGray800(brightness),
+            ),
+          ),
+          child: Column(
+            children: [
+              SizedBox(
+                height: 88,
+                child: Center(
+                  child: childBuilder(
+                    ValueKey(_playCounts[replayKey] ?? 0),
+                    sample,
+                  ),
+                ),
+              ),
+              CoconutLayout.spacing_300h,
+              CoconutButton(
+                text: 'Replay',
+                onPressed: () => _replay(replayKey),
+                isExpand: true,
+              ),
+            ],
+          ),
+        ),
+        CoconutLayout.spacing_600h,
+      ],
+    );
+  }
+
+  Widget _buildSampleCard(Brightness brightness, String title) {
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 10),
+      decoration: BoxDecoration(
+        color: CoconutColors.primary,
+        borderRadius: BorderRadius.circular(14),
+      ),
+      child: Text(
+        title,
+        style: CoconutTypography.body2_14_Bold.setColor(
+          CoconutColors.black,
+        ),
+      ),
+    );
+  }
+
+  Widget _buildTypewriterSample(Brightness brightness) {
+    return Container(
+      width: double.infinity,
+      padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 10),
+      decoration: BoxDecoration(
+        color: CoconutColors.primary.withValues(alpha: 0.2),
+        borderRadius: BorderRadius.circular(12),
+      ),
+      child: Text(
+        '',
+        style: CoconutTypography.body2_14_Bold.setColor(
+          CoconutColors.onBlack(brightness),
+        ),
+      ),
+    );
+  }
+
+  Widget _buildCharacterFadeSequenceExample(Brightness brightness) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Text(
+          'Character Fade Sequence',
+          style: CoconutTypography.body1_16_Bold.setColor(
+            CoconutColors.onPrimary(brightness),
+          ),
+        ),
+        CoconutLayout.spacing_300h,
+        _CharacterFadeSequenceDemo(brightness: brightness),
+        CoconutLayout.spacing_600h,
+      ],
+    );
+  }
+}
+
+enum _CharacterSequencePhase {
+  hidden,
+  entering,
+  visible,
+  exiting,
+}
+
+class _CharacterFadeSequenceDemo extends StatefulWidget {
+  const _CharacterFadeSequenceDemo({
+    required this.brightness,
+  });
+
+  final Brightness brightness;
+
+  @override
+  State<_CharacterFadeSequenceDemo> createState() => _CharacterFadeSequenceDemoState();
+}
+
+class _CharacterFadeSequenceDemoState extends State<_CharacterFadeSequenceDemo> {
+  static const _animationDuration = Duration(milliseconds: 600);
+  static const _sequenceText = 'Slide down fade in, then fade out slide up';
+
+  _CharacterSequencePhase _phase = _CharacterSequencePhase.hidden;
+  int _playCount = 0;
+
+  void _playSequence() {
+    setState(() {
+      if (_phase == _CharacterSequencePhase.hidden || _phase == _CharacterSequencePhase.exiting) {
+        _playCount += 1;
+        _phase = _CharacterSequencePhase.entering;
+      } else {
+        _playCount += 1;
+        _phase = _CharacterSequencePhase.exiting;
+      }
+    });
+  }
+
+  TextStyle get _sequenceTextStyle {
+    return CoconutTypography.body2_14_Bold.setColor(
+      CoconutColors.onBlack(widget.brightness),
+    );
+  }
+
+  Widget _buildEnteringAnimation() {
+    return CoconutCharacterFadeInAnimation(
+      key: ValueKey('enter_$_playCount'),
+      text: _sequenceText,
+      textStyle: _sequenceTextStyle,
+      duration: _animationDuration,
+      slideDirection: CoconutCharacterFadeSlideDirection.slideDown,
+      onCompleted: () {
+        if (!mounted || _phase != _CharacterSequencePhase.entering) return;
+
+        setState(() {
+          _phase = _CharacterSequencePhase.visible;
+        });
+      },
+    );
+  }
+
+  Widget _buildExitingAnimation() {
+    return CoconutCharacterFadeOutAnimation(
+      key: ValueKey('exit_$_playCount'),
+      text: _sequenceText,
+      textStyle: _sequenceTextStyle,
+      duration: _animationDuration,
+      slideDirection: CoconutCharacterFadeSlideDirection.slideUp,
+      onCompleted: () {
+        if (!mounted || _phase != _CharacterSequencePhase.exiting) return;
+
+        setState(() {
+          _phase = _CharacterSequencePhase.hidden;
+        });
+      },
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      width: double.infinity,
+      padding: const EdgeInsets.all(16),
+      decoration: BoxDecoration(
+        color: CoconutColors.onGray100(widget.brightness),
+        borderRadius: BorderRadius.circular(16),
+        border: Border.all(
+          color: CoconutColors.onGray800(widget.brightness),
+        ),
+      ),
+      child: Column(
+        children: [
+          SizedBox(
+            height: 88,
+            child: Center(
+              child: switch (_phase) {
+                _CharacterSequencePhase.hidden => const SizedBox.shrink(),
+                _CharacterSequencePhase.entering ||
+                _CharacterSequencePhase.visible =>
+                  _buildEnteringAnimation(),
+                _CharacterSequencePhase.exiting => _buildExitingAnimation(),
+              },
+            ),
+          ),
+          CoconutLayout.spacing_300h,
+          CoconutButton(
+            text: _phase == _CharacterSequencePhase.hidden ||
+                    _phase == _CharacterSequencePhase.exiting
+                ? 'Show'
+                : 'Hide',
+            onPressed: _playSequence,
+            isExpand: true,
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/example/lib/screens/inputs.dart
+++ b/example/lib/screens/inputs.dart
@@ -272,6 +272,15 @@ class _InputsScreenState extends State<InputsScreen> {
                           ),
                           const SizedBox(height: 10),
                           CoconutTextField(
+                            controller: controller2,
+                            focusNode: focusNode2,
+                            brightness: brightness,
+                            style: CoconutTextFieldStyle.underline,
+                            placeholderText: 'Placeholder text',
+                            onChanged: (text) {},
+                          ),
+                          const SizedBox(height: 10),
+                          CoconutTextField(
                             controller: controller3,
                             focusNode: focusNode3,
                             brightness: brightness,

--- a/example/lib/screens/inputs.dart
+++ b/example/lib/screens/inputs.dart
@@ -358,6 +358,14 @@ class _InputsScreenState extends State<InputsScreen> {
                           CoconutOptionPicker(
                             text: 'CoconutOptionPicker Test',
                             label: 'Test Label',
+                            inlineWidget: Container(
+                              decoration: BoxDecoration(
+                                  border: Border.all(color: CoconutColors.cyanBlue, width: 1)),
+                              child: const Text(
+                                'This is OptionBox',
+                                style: CoconutTypography.caption_10,
+                              ),
+                            ),
                             onTap: () {
                               // BottomSheet 호출과 같이 Tap에 대한 작동 로직은 사용하는 화면에서 제어해야 함
                               CoconutOptionStateEnum draftOptionPickerState = optionPickerState;

--- a/example/lib/screens/inputs.dart
+++ b/example/lib/screens/inputs.dart
@@ -358,7 +358,7 @@ class _InputsScreenState extends State<InputsScreen> {
                           CoconutOptionPicker(
                             text: 'CoconutOptionPicker Test',
                             label: 'Test Label',
-                            inlineWidget: Container(
+                            subWidget: Container(
                               decoration: BoxDecoration(
                                   border: Border.all(color: CoconutColors.cyanBlue, width: 1)),
                               child: const Text(

--- a/example/lib/screens/inputs.dart
+++ b/example/lib/screens/inputs.dart
@@ -14,6 +14,7 @@ class InputsScreen extends StatefulWidget {
 
 class _InputsScreenState extends State<InputsScreen> {
   CoconutChipStatus chipStatus = CoconutChipStatus.unselected;
+  CoconutOptionStateEnum optionPickerState = CoconutOptionStateEnum.warning;
 
   bool isCheckbox1Selected = false;
   bool isCheckbox2Selected = false;
@@ -285,7 +286,9 @@ class _InputsScreenState extends State<InputsScreen> {
                               child: Container(
                                 margin: const EdgeInsets.only(right: 13),
                                 child: SvgPicture.asset(
-                                  obscureText ? 'assets/svg/textfield_hide.svg' : 'assets/svg/textfield_view.svg',
+                                  obscureText
+                                      ? 'assets/svg/textfield_hide.svg'
+                                      : 'assets/svg/textfield_view.svg',
                                   width: 16,
                                   height: 16,
                                   colorFilter: ColorFilter.mode(
@@ -350,6 +353,100 @@ class _InputsScreenState extends State<InputsScreen> {
                               setState(() {});
                             },
                           ),
+                          CoconutLayout.spacing_600h,
+                          _titleBox('Option Picker', brightness),
+                          CoconutOptionPicker(
+                            text: 'CoconutOptionPicker Test',
+                            label: 'Test Label',
+                            onTap: () {
+                              // BottomSheet 호출과 같이 Tap에 대한 작동 로직은 사용하는 화면에서 제어해야 함
+                              CoconutOptionStateEnum draftOptionPickerState = optionPickerState;
+                              showModalBottomSheet(
+                                context: context,
+                                isScrollControlled: true,
+                                builder: (context) => CoconutBottomSheet(
+                                  useIntrinsicHeight: true,
+                                  appBar: CoconutAppBar.build(
+                                    title: 'CoconutOptionPicker Options',
+                                    context: context,
+                                    isBottom: true,
+                                  ),
+                                  body: StatefulBuilder(
+                                    builder: (context, setBottomSheetState) {
+                                      Widget buildOptionButton({
+                                        required String title,
+                                        required CoconutOptionStateEnum state,
+                                      }) {
+                                        final isSelected = draftOptionPickerState == state;
+
+                                        return Padding(
+                                          padding: const EdgeInsets.only(bottom: 12),
+                                          child: CoconutButton(
+                                            text: title,
+                                            isExpand: true,
+                                            buttonType: isSelected
+                                                ? CoconutButtonType.filled
+                                                : CoconutButtonType.outlined,
+                                            backgroundColor: isSelected
+                                                ? CoconutColors.normalPrimaryButtonColor()
+                                                : Colors.transparent,
+                                            foregroundColor: isSelected
+                                                ? CoconutColors.primaryButtonLabelColor()
+                                                : CoconutColors.onBlack(brightness),
+                                            borderColor: isSelected
+                                                ? CoconutColors.normalPrimaryButtonColor()
+                                                : CoconutColors.onGray700(brightness),
+                                            onPressed: () {
+                                              setBottomSheetState(() {
+                                                draftOptionPickerState = state;
+                                              });
+                                            },
+                                          ),
+                                        );
+                                      }
+
+                                      return Padding(
+                                        padding: const EdgeInsets.all(CoconutLayout.defaultPadding),
+                                        child: Column(
+                                          children: [
+                                            buildOptionButton(
+                                              title: 'normal',
+                                              state: CoconutOptionStateEnum.normal,
+                                            ),
+                                            buildOptionButton(
+                                              title: 'warning',
+                                              state: CoconutOptionStateEnum.warning,
+                                            ),
+                                            buildOptionButton(
+                                              title: 'error',
+                                              state: CoconutOptionStateEnum.error,
+                                            ),
+                                            CoconutLayout.spacing_300h,
+                                            CoconutButton(
+                                                onPressed: () {
+                                                  optionPickerState = draftOptionPickerState;
+                                                  setState(() {});
+                                                  Navigator.pop(context);
+                                                },
+                                                text: 'Complete')
+                                          ],
+                                        ),
+                                      );
+                                    },
+                                  ),
+                                ),
+                              );
+                            },
+                            coconutOptionStateEnum: optionPickerState,
+                            guideText: 'guide test',
+                            inlineWidgets: const [
+                              CoconutChip(
+                                label: '#non-kyc',
+                                color: CoconutColors.yellow,
+                              ),
+                            ],
+                          ),
+                          CoconutLayout.spacing_2500h,
                         ],
                       ),
                     ],

--- a/lib/coconut_design_system.dart
+++ b/lib/coconut_design_system.dart
@@ -11,6 +11,7 @@ export 'src/components/appbar_button.dart';
 export 'src/components/inputs/tag_chip.dart';
 export 'src/components/inputs/checkbox.dart';
 export 'src/components/inputs/chip.dart';
+export 'src/components/inputs/option-picker.dart';
 export 'src/components/inputs/pulldown.dart';
 export 'src/components/inputs/stepper.dart';
 export 'src/components/inputs/switch.dart';

--- a/lib/coconut_design_system.dart
+++ b/lib/coconut_design_system.dart
@@ -24,7 +24,22 @@ export 'src/components/overlays/tooltip.dart';
 export 'src/components/overlays/toast.dart';
 export 'src/components/indicator/progress_indicator.dart';
 export 'src/components/indicator/circular_indicator.dart';
+export 'src/animation/bounce_in_animation.dart';
+export 'src/animation/bounce_out_animation.dart';
+export 'src/animation/character_fade_in_animation.dart';
+export 'src/animation/character_fade_out_animation.dart';
+export 'src/animation/fade_in_animation.dart';
+export 'src/animation/fade_out_animation.dart';
 export 'src/animation/shake_animation.dart';
+export 'src/animation/scale_in_animation.dart';
+export 'src/animation/scale_out_animation.dart';
+export 'src/animation/slide_down_animation.dart';
+export 'src/animation/slide_left_animation.dart';
+export 'src/animation/slide_right_animation.dart';
+export 'src/animation/slide_up_animation.dart';
+export 'src/animation/typewriter_animation.dart';
+export 'src/animation/zoom_in_animation.dart';
+export 'src/animation/zoom_out_animation.dart';
 
 // 📌 Theme & Styling
 export 'src/theme/typography.dart';

--- a/lib/src/animation/bounce_in_animation.dart
+++ b/lib/src/animation/bounce_in_animation.dart
@@ -1,0 +1,38 @@
+import 'package:coconut_design_system/src/animation/transition_animation.dart';
+import 'package:flutter/material.dart';
+
+class CoconutBounceInAnimation extends StatelessWidget {
+  const CoconutBounceInAnimation({
+    super.key,
+    required this.child,
+    this.duration = const Duration(milliseconds: 420),
+    this.beginScale = 0.78,
+    this.curve = Curves.elasticOut,
+    this.autoStart = true,
+    this.onCompleted,
+  });
+
+  final Widget child;
+  final Duration duration;
+  final double beginScale;
+  final Curve curve;
+  final bool autoStart;
+  final VoidCallback? onCompleted;
+
+  @override
+  Widget build(BuildContext context) {
+    return CoconutTransitionAnimation(
+      duration: duration,
+      beginOffset: Offset.zero,
+      endOffset: Offset.zero,
+      beginOpacity: 0,
+      endOpacity: 1,
+      beginScale: beginScale,
+      endScale: 1,
+      curve: curve,
+      autoStart: autoStart,
+      onCompleted: onCompleted,
+      child: child,
+    );
+  }
+}

--- a/lib/src/animation/bounce_in_animation.dart
+++ b/lib/src/animation/bounce_in_animation.dart
@@ -6,6 +6,7 @@ class CoconutBounceInAnimation extends StatelessWidget {
     super.key,
     required this.child,
     this.duration = const Duration(milliseconds: 420),
+    this.delay = Duration.zero,
     this.beginScale = 0.78,
     this.curve = Curves.elasticOut,
     this.autoStart = true,
@@ -14,6 +15,7 @@ class CoconutBounceInAnimation extends StatelessWidget {
 
   final Widget child;
   final Duration duration;
+  final Duration delay;
   final double beginScale;
   final Curve curve;
   final bool autoStart;
@@ -23,6 +25,7 @@ class CoconutBounceInAnimation extends StatelessWidget {
   Widget build(BuildContext context) {
     return CoconutTransitionAnimation(
       duration: duration,
+      delay: delay,
       beginOffset: Offset.zero,
       endOffset: Offset.zero,
       beginOpacity: 0,

--- a/lib/src/animation/bounce_out_animation.dart
+++ b/lib/src/animation/bounce_out_animation.dart
@@ -6,6 +6,7 @@ class CoconutBounceOutAnimation extends StatelessWidget {
     super.key,
     required this.child,
     this.duration = const Duration(milliseconds: 280),
+    this.delay = Duration.zero,
     this.endScale = 0.7,
     this.curve = Curves.easeInBack,
     this.autoStart = true,
@@ -14,6 +15,7 @@ class CoconutBounceOutAnimation extends StatelessWidget {
 
   final Widget child;
   final Duration duration;
+  final Duration delay;
   final double endScale;
   final Curve curve;
   final bool autoStart;
@@ -23,6 +25,7 @@ class CoconutBounceOutAnimation extends StatelessWidget {
   Widget build(BuildContext context) {
     return CoconutTransitionAnimation(
       duration: duration,
+      delay: delay,
       beginOffset: Offset.zero,
       endOffset: Offset.zero,
       beginOpacity: 1,

--- a/lib/src/animation/bounce_out_animation.dart
+++ b/lib/src/animation/bounce_out_animation.dart
@@ -1,0 +1,38 @@
+import 'package:coconut_design_system/src/animation/transition_animation.dart';
+import 'package:flutter/material.dart';
+
+class CoconutBounceOutAnimation extends StatelessWidget {
+  const CoconutBounceOutAnimation({
+    super.key,
+    required this.child,
+    this.duration = const Duration(milliseconds: 280),
+    this.endScale = 0.7,
+    this.curve = Curves.easeInBack,
+    this.autoStart = true,
+    this.onCompleted,
+  });
+
+  final Widget child;
+  final Duration duration;
+  final double endScale;
+  final Curve curve;
+  final bool autoStart;
+  final VoidCallback? onCompleted;
+
+  @override
+  Widget build(BuildContext context) {
+    return CoconutTransitionAnimation(
+      duration: duration,
+      beginOffset: Offset.zero,
+      endOffset: Offset.zero,
+      beginOpacity: 1,
+      endOpacity: 0,
+      beginScale: 1,
+      endScale: endScale,
+      curve: curve,
+      autoStart: autoStart,
+      onCompleted: onCompleted,
+      child: child,
+    );
+  }
+}

--- a/lib/src/animation/character_fade_in_animation.dart
+++ b/lib/src/animation/character_fade_in_animation.dart
@@ -1,0 +1,256 @@
+import 'package:flutter/material.dart';
+
+/// Defines the optional slide direction used during the character fade-in animation.
+enum CoconutCharacterFadeSlideDirection {
+  none,
+  slideUp,
+  slideDown,
+}
+
+/// A text animation widget that fades in each character sequentially
+/// while keeping the final text layout fixed from the start.
+///
+/// Unlike a typewriter animation, this widget does not shift the position of
+/// later characters as the animation progresses. Every character already
+/// occupies its final position and becomes visible with a staggered fade-in.
+///
+/// You can also combine the fade effect with an optional vertical slide so that
+/// each character fades in while moving up or down into place.
+///
+/// Example usage:
+/// ```dart
+/// CoconutCharacterFadeInAnimation(
+///   text: 'Hello Coconut',
+///   textStyle: TextStyle(fontSize: 16),
+///   autoStart: true,
+/// )
+/// ```
+class CoconutCharacterFadeInAnimation extends StatefulWidget {
+  const CoconutCharacterFadeInAnimation({
+    super.key,
+    required this.text,
+    this.textStyle,
+    this.textAlign,
+    this.maxLines,
+    this.overflow,
+    this.duration = const Duration(milliseconds: 1200),
+    this.curve = Curves.easeOut,
+    this.autoStart = true,
+    this.fadePortion = 0.45,
+    this.slideDirection = CoconutCharacterFadeSlideDirection.none,
+    this.slideOffset = 8,
+    this.onCompleted,
+  });
+
+  /// The full text to reveal progressively.
+  final String text;
+
+  /// The style applied to the animated text.
+  final TextStyle? textStyle;
+
+  /// How the text should be aligned horizontally.
+  final TextAlign? textAlign;
+
+  /// The maximum number of lines for the text.
+  final int? maxLines;
+
+  /// The overflow behavior of the text.
+  final TextOverflow? overflow;
+
+  /// The total duration required to reveal the full text.
+  final Duration duration;
+
+  /// The animation curve used for the character reveal progression.
+  final Curve curve;
+
+  /// Whether to start the animation automatically after the first frame.
+  final bool autoStart;
+
+  /// The portion of each character interval used for the fade transition.
+  ///
+  /// Larger values create more overlap between neighboring character fades.
+  final double fadePortion;
+
+  /// The optional vertical slide direction applied during the fade-in.
+  final CoconutCharacterFadeSlideDirection slideDirection;
+
+  /// The vertical distance in logical pixels used for the slide animation.
+  final double slideOffset;
+
+  /// Callback triggered when the animation completes.
+  final VoidCallback? onCompleted;
+
+  @override
+  State<CoconutCharacterFadeInAnimation> createState() => _CoconutCharacterFadeInAnimationState();
+}
+
+class _CoconutCharacterFadeInAnimationState extends State<CoconutCharacterFadeInAnimation>
+    with SingleTickerProviderStateMixin {
+  late final AnimationController _controller;
+  late Animation<double> _progressAnimation;
+
+  @override
+  void initState() {
+    super.initState();
+    _controller = AnimationController(
+      vsync: this,
+      duration: widget.duration,
+    );
+    _progressAnimation = CurvedAnimation(
+      parent: _controller,
+      curve: widget.curve,
+    );
+
+    _controller.addStatusListener((status) {
+      if (status == AnimationStatus.completed) {
+        widget.onCompleted?.call();
+      }
+    });
+
+    if (widget.autoStart) {
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        if (mounted) {
+          start();
+        }
+      });
+    }
+  }
+
+  @override
+  void didUpdateWidget(covariant CoconutCharacterFadeInAnimation oldWidget) {
+    super.didUpdateWidget(oldWidget);
+
+    if (oldWidget.duration != widget.duration) {
+      _controller.duration = widget.duration;
+    }
+
+    if (oldWidget.curve != widget.curve) {
+      _progressAnimation = CurvedAnimation(
+        parent: _controller,
+        curve: widget.curve,
+      );
+    }
+
+    if (oldWidget.text != widget.text && widget.autoStart) {
+      start();
+    }
+  }
+
+  /// Restarts the character fade-in animation from the beginning.
+  void start() {
+    _controller.forward(from: 0);
+  }
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final characters = widget.text.characters.toList(growable: false);
+    final baseStyle = widget.textStyle ?? DefaultTextStyle.of(context).style;
+    final baseColor = baseStyle.color ?? DefaultTextStyle.of(context).style.color;
+
+    return AnimatedBuilder(
+      animation: _progressAnimation,
+      builder: (context, child) {
+        final spans = <InlineSpan>[];
+        final total = characters.length;
+
+        for (int index = 0; index < total; index++) {
+          final opacity = _resolveCharacterOpacity(
+            index: index,
+            totalCount: total,
+            progress: _progressAnimation.value,
+          );
+          final dy = _resolveCharacterDy(
+            index: index,
+            totalCount: total,
+            progress: _progressAnimation.value,
+          );
+
+          spans.add(
+            WidgetSpan(
+              alignment: PlaceholderAlignment.baseline,
+              baseline: TextBaseline.alphabetic,
+              child: Transform.translate(
+                offset: Offset(0, dy),
+                child: Opacity(
+                  opacity: opacity,
+                  child: Text(
+                    characters[index],
+                    style: baseStyle.copyWith(
+                      color: baseColor,
+                    ),
+                  ),
+                ),
+              ),
+            ),
+          );
+        }
+
+        return Text.rich(
+          TextSpan(
+            style: baseStyle,
+            children: spans,
+          ),
+          textAlign: widget.textAlign,
+          maxLines: widget.maxLines,
+          overflow: widget.overflow,
+        );
+      },
+    );
+  }
+
+  double _resolveCharacterOpacity({
+    required int index,
+    required int totalCount,
+    required double progress,
+  }) {
+    if (totalCount <= 0) return 1;
+
+    final step = 1 / totalCount;
+    final start = index * step;
+    final end = (start + (step * widget.fadePortion)).clamp(start + 0.0001, 1.0);
+
+    if (progress <= start) return 0;
+    if (progress >= end) return 1;
+
+    return ((progress - start) / (end - start)).clamp(0.0, 1.0);
+  }
+
+  double _resolveCharacterDy({
+    required int index,
+    required int totalCount,
+    required double progress,
+  }) {
+    if (widget.slideDirection == CoconutCharacterFadeSlideDirection.none || totalCount <= 0) {
+      return 0;
+    }
+
+    final step = 1 / totalCount;
+    final start = index * step;
+    final end = (start + (step * widget.fadePortion)).clamp(start + 0.0001, 1.0);
+
+    if (progress <= start) {
+      return _initialSlideOffset;
+    }
+
+    if (progress >= end) {
+      return 0;
+    }
+
+    final t = ((progress - start) / (end - start)).clamp(0.0, 1.0);
+    return _initialSlideOffset * (1 - t);
+  }
+
+  double get _initialSlideOffset {
+    return switch (widget.slideDirection) {
+      CoconutCharacterFadeSlideDirection.none => 0,
+      CoconutCharacterFadeSlideDirection.slideUp => widget.slideOffset,
+      CoconutCharacterFadeSlideDirection.slideDown => -widget.slideOffset,
+    };
+  }
+}

--- a/lib/src/animation/character_fade_in_animation.dart
+++ b/lib/src/animation/character_fade_in_animation.dart
@@ -34,6 +34,7 @@ class CoconutCharacterFadeInAnimation extends StatefulWidget {
     this.maxLines,
     this.overflow,
     this.duration = const Duration(milliseconds: 1200),
+    this.delay = Duration.zero,
     this.curve = Curves.easeOut,
     this.autoStart = true,
     this.fadePortion = 0.45,
@@ -59,6 +60,9 @@ class CoconutCharacterFadeInAnimation extends StatefulWidget {
 
   /// The total duration required to reveal the full text.
   final Duration duration;
+
+  /// Delay before the animation starts automatically.
+  final Duration delay;
 
   /// The animation curve used for the character reveal progression.
   final Curve curve;
@@ -88,6 +92,7 @@ class _CoconutCharacterFadeInAnimationState extends State<CoconutCharacterFadeIn
     with SingleTickerProviderStateMixin {
   late final AnimationController _controller;
   late Animation<double> _progressAnimation;
+  int _startToken = 0;
 
   @override
   void initState() {
@@ -110,7 +115,7 @@ class _CoconutCharacterFadeInAnimationState extends State<CoconutCharacterFadeIn
     if (widget.autoStart) {
       WidgetsBinding.instance.addPostFrameCallback((_) {
         if (mounted) {
-          start();
+          _startWithDelay();
         }
       });
     }
@@ -132,13 +137,26 @@ class _CoconutCharacterFadeInAnimationState extends State<CoconutCharacterFadeIn
     }
 
     if (oldWidget.text != widget.text && widget.autoStart) {
-      start();
+      _startWithDelay();
     }
   }
 
   /// Restarts the character fade-in animation from the beginning.
   void start() {
     _controller.forward(from: 0);
+  }
+
+  void _startWithDelay() {
+    final token = ++_startToken;
+    if (widget.delay <= Duration.zero) {
+      start();
+      return;
+    }
+
+    Future<void>.delayed(widget.delay, () {
+      if (!mounted || token != _startToken) return;
+      start();
+    });
   }
 
   @override

--- a/lib/src/animation/character_fade_out_animation.dart
+++ b/lib/src/animation/character_fade_out_animation.dart
@@ -1,0 +1,209 @@
+import 'package:coconut_design_system/src/animation/character_fade_in_animation.dart';
+import 'package:flutter/material.dart';
+
+/// A text animation widget that fades out each character sequentially
+/// while keeping the final text layout fixed from the start.
+///
+/// You can also combine the fade effect with an optional vertical slide so that
+/// each character fades out while moving up or down.
+class CoconutCharacterFadeOutAnimation extends StatefulWidget {
+  const CoconutCharacterFadeOutAnimation({
+    super.key,
+    required this.text,
+    this.textStyle,
+    this.textAlign,
+    this.maxLines,
+    this.overflow,
+    this.duration = const Duration(milliseconds: 1200),
+    this.curve = Curves.easeIn,
+    this.autoStart = true,
+    this.fadePortion = 0.45,
+    this.slideDirection = CoconutCharacterFadeSlideDirection.none,
+    this.slideOffset = 8,
+    this.onCompleted,
+  });
+
+  final String text;
+  final TextStyle? textStyle;
+  final TextAlign? textAlign;
+  final int? maxLines;
+  final TextOverflow? overflow;
+  final Duration duration;
+  final Curve curve;
+  final bool autoStart;
+  final double fadePortion;
+  final CoconutCharacterFadeSlideDirection slideDirection;
+  final double slideOffset;
+  final VoidCallback? onCompleted;
+
+  @override
+  State<CoconutCharacterFadeOutAnimation> createState() => _CoconutCharacterFadeOutAnimationState();
+}
+
+class _CoconutCharacterFadeOutAnimationState extends State<CoconutCharacterFadeOutAnimation>
+    with SingleTickerProviderStateMixin {
+  late final AnimationController _controller;
+  late Animation<double> _progressAnimation;
+
+  @override
+  void initState() {
+    super.initState();
+    _controller = AnimationController(
+      vsync: this,
+      duration: widget.duration,
+    );
+    _progressAnimation = CurvedAnimation(
+      parent: _controller,
+      curve: widget.curve,
+    );
+
+    _controller.addStatusListener((status) {
+      if (status == AnimationStatus.completed) {
+        widget.onCompleted?.call();
+      }
+    });
+
+    if (widget.autoStart) {
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        if (mounted) {
+          start();
+        }
+      });
+    }
+  }
+
+  @override
+  void didUpdateWidget(covariant CoconutCharacterFadeOutAnimation oldWidget) {
+    super.didUpdateWidget(oldWidget);
+
+    if (oldWidget.duration != widget.duration) {
+      _controller.duration = widget.duration;
+    }
+
+    if (oldWidget.curve != widget.curve) {
+      _progressAnimation = CurvedAnimation(
+        parent: _controller,
+        curve: widget.curve,
+      );
+    }
+
+    if (oldWidget.text != widget.text && widget.autoStart) {
+      start();
+    }
+  }
+
+  void start() {
+    _controller.forward(from: 0);
+  }
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final characters = widget.text.characters.toList(growable: false);
+    final baseStyle = widget.textStyle ?? DefaultTextStyle.of(context).style;
+    final baseColor = baseStyle.color ?? DefaultTextStyle.of(context).style.color;
+
+    return AnimatedBuilder(
+      animation: _progressAnimation,
+      builder: (context, child) {
+        final spans = <InlineSpan>[];
+        final total = characters.length;
+
+        for (int index = 0; index < total; index++) {
+          final opacity = _resolveCharacterOpacity(
+            index: index,
+            totalCount: total,
+            progress: _progressAnimation.value,
+          );
+          final dy = _resolveCharacterDy(
+            index: index,
+            totalCount: total,
+            progress: _progressAnimation.value,
+          );
+
+          spans.add(
+            WidgetSpan(
+              alignment: PlaceholderAlignment.baseline,
+              baseline: TextBaseline.alphabetic,
+              child: Transform.translate(
+                offset: Offset(0, dy),
+                child: Opacity(
+                  opacity: opacity,
+                  child: Text(
+                    characters[index],
+                    style: baseStyle.copyWith(color: baseColor),
+                  ),
+                ),
+              ),
+            ),
+          );
+        }
+
+        return Text.rich(
+          TextSpan(
+            style: baseStyle,
+            children: spans,
+          ),
+          textAlign: widget.textAlign,
+          maxLines: widget.maxLines,
+          overflow: widget.overflow,
+        );
+      },
+    );
+  }
+
+  double _resolveCharacterOpacity({
+    required int index,
+    required int totalCount,
+    required double progress,
+  }) {
+    if (totalCount <= 0) return 0;
+
+    final step = 1 / totalCount;
+    final start = index * step;
+    final end = (start + (step * widget.fadePortion)).clamp(start + 0.0001, 1.0);
+
+    if (progress <= start) return 1;
+    if (progress >= end) return 0;
+
+    return (1 - ((progress - start) / (end - start))).clamp(0.0, 1.0);
+  }
+
+  double _resolveCharacterDy({
+    required int index,
+    required int totalCount,
+    required double progress,
+  }) {
+    if (widget.slideDirection == CoconutCharacterFadeSlideDirection.none || totalCount <= 0) {
+      return 0;
+    }
+
+    final step = 1 / totalCount;
+    final start = index * step;
+    final end = (start + (step * widget.fadePortion)).clamp(start + 0.0001, 1.0);
+
+    if (progress <= start) {
+      return 0;
+    }
+
+    if (progress >= end) {
+      return _finalSlideOffset;
+    }
+
+    final t = ((progress - start) / (end - start)).clamp(0.0, 1.0);
+    return _finalSlideOffset * t;
+  }
+
+  double get _finalSlideOffset {
+    return switch (widget.slideDirection) {
+      CoconutCharacterFadeSlideDirection.none => 0,
+      CoconutCharacterFadeSlideDirection.slideUp => -widget.slideOffset,
+      CoconutCharacterFadeSlideDirection.slideDown => widget.slideOffset,
+    };
+  }
+}

--- a/lib/src/animation/character_fade_out_animation.dart
+++ b/lib/src/animation/character_fade_out_animation.dart
@@ -15,6 +15,7 @@ class CoconutCharacterFadeOutAnimation extends StatefulWidget {
     this.maxLines,
     this.overflow,
     this.duration = const Duration(milliseconds: 1200),
+    this.delay = Duration.zero,
     this.curve = Curves.easeIn,
     this.autoStart = true,
     this.fadePortion = 0.45,
@@ -29,6 +30,7 @@ class CoconutCharacterFadeOutAnimation extends StatefulWidget {
   final int? maxLines;
   final TextOverflow? overflow;
   final Duration duration;
+  final Duration delay;
   final Curve curve;
   final bool autoStart;
   final double fadePortion;
@@ -44,6 +46,7 @@ class _CoconutCharacterFadeOutAnimationState extends State<CoconutCharacterFadeO
     with SingleTickerProviderStateMixin {
   late final AnimationController _controller;
   late Animation<double> _progressAnimation;
+  int _startToken = 0;
 
   @override
   void initState() {
@@ -66,7 +69,7 @@ class _CoconutCharacterFadeOutAnimationState extends State<CoconutCharacterFadeO
     if (widget.autoStart) {
       WidgetsBinding.instance.addPostFrameCallback((_) {
         if (mounted) {
-          start();
+          _startWithDelay();
         }
       });
     }
@@ -88,12 +91,25 @@ class _CoconutCharacterFadeOutAnimationState extends State<CoconutCharacterFadeO
     }
 
     if (oldWidget.text != widget.text && widget.autoStart) {
-      start();
+      _startWithDelay();
     }
   }
 
   void start() {
     _controller.forward(from: 0);
+  }
+
+  void _startWithDelay() {
+    final token = ++_startToken;
+    if (widget.delay <= Duration.zero) {
+      start();
+      return;
+    }
+
+    Future<void>.delayed(widget.delay, () {
+      if (!mounted || token != _startToken) return;
+      start();
+    });
   }
 
   @override

--- a/lib/src/animation/fade_in_animation.dart
+++ b/lib/src/animation/fade_in_animation.dart
@@ -1,0 +1,36 @@
+import 'package:coconut_design_system/src/animation/transition_animation.dart';
+import 'package:flutter/material.dart';
+
+class CoconutFadeInAnimation extends StatelessWidget {
+  const CoconutFadeInAnimation({
+    super.key,
+    required this.child,
+    this.duration = const Duration(milliseconds: 220),
+    this.curve = Curves.easeOut,
+    this.autoStart = true,
+    this.onCompleted,
+  });
+
+  final Widget child;
+  final Duration duration;
+  final Curve curve;
+  final bool autoStart;
+  final VoidCallback? onCompleted;
+
+  @override
+  Widget build(BuildContext context) {
+    return CoconutTransitionAnimation(
+      duration: duration,
+      beginOffset: Offset.zero,
+      endOffset: Offset.zero,
+      beginOpacity: 0,
+      endOpacity: 1,
+      beginScale: 1,
+      endScale: 1,
+      curve: curve,
+      autoStart: autoStart,
+      onCompleted: onCompleted,
+      child: child,
+    );
+  }
+}

--- a/lib/src/animation/fade_in_animation.dart
+++ b/lib/src/animation/fade_in_animation.dart
@@ -6,6 +6,7 @@ class CoconutFadeInAnimation extends StatelessWidget {
     super.key,
     required this.child,
     this.duration = const Duration(milliseconds: 220),
+    this.delay = Duration.zero,
     this.curve = Curves.easeOut,
     this.autoStart = true,
     this.onCompleted,
@@ -13,6 +14,7 @@ class CoconutFadeInAnimation extends StatelessWidget {
 
   final Widget child;
   final Duration duration;
+  final Duration delay;
   final Curve curve;
   final bool autoStart;
   final VoidCallback? onCompleted;
@@ -21,6 +23,7 @@ class CoconutFadeInAnimation extends StatelessWidget {
   Widget build(BuildContext context) {
     return CoconutTransitionAnimation(
       duration: duration,
+      delay: delay,
       beginOffset: Offset.zero,
       endOffset: Offset.zero,
       beginOpacity: 0,

--- a/lib/src/animation/fade_out_animation.dart
+++ b/lib/src/animation/fade_out_animation.dart
@@ -6,6 +6,7 @@ class CoconutFadeOutAnimation extends StatelessWidget {
     super.key,
     required this.child,
     this.duration = const Duration(milliseconds: 220),
+    this.delay = Duration.zero,
     this.curve = Curves.easeIn,
     this.autoStart = true,
     this.onCompleted,
@@ -13,6 +14,7 @@ class CoconutFadeOutAnimation extends StatelessWidget {
 
   final Widget child;
   final Duration duration;
+  final Duration delay;
   final Curve curve;
   final bool autoStart;
   final VoidCallback? onCompleted;
@@ -21,6 +23,7 @@ class CoconutFadeOutAnimation extends StatelessWidget {
   Widget build(BuildContext context) {
     return CoconutTransitionAnimation(
       duration: duration,
+      delay: delay,
       beginOffset: Offset.zero,
       endOffset: Offset.zero,
       beginOpacity: 1,

--- a/lib/src/animation/fade_out_animation.dart
+++ b/lib/src/animation/fade_out_animation.dart
@@ -1,0 +1,36 @@
+import 'package:coconut_design_system/src/animation/transition_animation.dart';
+import 'package:flutter/material.dart';
+
+class CoconutFadeOutAnimation extends StatelessWidget {
+  const CoconutFadeOutAnimation({
+    super.key,
+    required this.child,
+    this.duration = const Duration(milliseconds: 220),
+    this.curve = Curves.easeIn,
+    this.autoStart = true,
+    this.onCompleted,
+  });
+
+  final Widget child;
+  final Duration duration;
+  final Curve curve;
+  final bool autoStart;
+  final VoidCallback? onCompleted;
+
+  @override
+  Widget build(BuildContext context) {
+    return CoconutTransitionAnimation(
+      duration: duration,
+      beginOffset: Offset.zero,
+      endOffset: Offset.zero,
+      beginOpacity: 1,
+      endOpacity: 0,
+      beginScale: 1,
+      endScale: 1,
+      curve: curve,
+      autoStart: autoStart,
+      onCompleted: onCompleted,
+      child: child,
+    );
+  }
+}

--- a/lib/src/animation/scale_in_animation.dart
+++ b/lib/src/animation/scale_in_animation.dart
@@ -6,6 +6,7 @@ class CoconutScaleInAnimation extends StatelessWidget {
     super.key,
     required this.child,
     this.duration = const Duration(milliseconds: 240),
+    this.delay = Duration.zero,
     this.beginScale = 0.92,
     this.curve = Curves.easeOutCubic,
     this.autoStart = true,
@@ -14,6 +15,7 @@ class CoconutScaleInAnimation extends StatelessWidget {
 
   final Widget child;
   final Duration duration;
+  final Duration delay;
   final double beginScale;
   final Curve curve;
   final bool autoStart;
@@ -23,6 +25,7 @@ class CoconutScaleInAnimation extends StatelessWidget {
   Widget build(BuildContext context) {
     return CoconutTransitionAnimation(
       duration: duration,
+      delay: delay,
       beginOffset: Offset.zero,
       endOffset: Offset.zero,
       beginOpacity: 0,

--- a/lib/src/animation/scale_in_animation.dart
+++ b/lib/src/animation/scale_in_animation.dart
@@ -1,0 +1,38 @@
+import 'package:coconut_design_system/src/animation/transition_animation.dart';
+import 'package:flutter/material.dart';
+
+class CoconutScaleInAnimation extends StatelessWidget {
+  const CoconutScaleInAnimation({
+    super.key,
+    required this.child,
+    this.duration = const Duration(milliseconds: 240),
+    this.beginScale = 0.92,
+    this.curve = Curves.easeOutCubic,
+    this.autoStart = true,
+    this.onCompleted,
+  });
+
+  final Widget child;
+  final Duration duration;
+  final double beginScale;
+  final Curve curve;
+  final bool autoStart;
+  final VoidCallback? onCompleted;
+
+  @override
+  Widget build(BuildContext context) {
+    return CoconutTransitionAnimation(
+      duration: duration,
+      beginOffset: Offset.zero,
+      endOffset: Offset.zero,
+      beginOpacity: 0,
+      endOpacity: 1,
+      beginScale: beginScale,
+      endScale: 1,
+      curve: curve,
+      autoStart: autoStart,
+      onCompleted: onCompleted,
+      child: child,
+    );
+  }
+}

--- a/lib/src/animation/scale_out_animation.dart
+++ b/lib/src/animation/scale_out_animation.dart
@@ -6,6 +6,7 @@ class CoconutScaleOutAnimation extends StatelessWidget {
     super.key,
     required this.child,
     this.duration = const Duration(milliseconds: 220),
+    this.delay = Duration.zero,
     this.endScale = 0.92,
     this.curve = Curves.easeInCubic,
     this.autoStart = true,
@@ -14,6 +15,7 @@ class CoconutScaleOutAnimation extends StatelessWidget {
 
   final Widget child;
   final Duration duration;
+  final Duration delay;
   final double endScale;
   final Curve curve;
   final bool autoStart;
@@ -23,6 +25,7 @@ class CoconutScaleOutAnimation extends StatelessWidget {
   Widget build(BuildContext context) {
     return CoconutTransitionAnimation(
       duration: duration,
+      delay: delay,
       beginOffset: Offset.zero,
       endOffset: Offset.zero,
       beginOpacity: 1,

--- a/lib/src/animation/scale_out_animation.dart
+++ b/lib/src/animation/scale_out_animation.dart
@@ -1,0 +1,38 @@
+import 'package:coconut_design_system/src/animation/transition_animation.dart';
+import 'package:flutter/material.dart';
+
+class CoconutScaleOutAnimation extends StatelessWidget {
+  const CoconutScaleOutAnimation({
+    super.key,
+    required this.child,
+    this.duration = const Duration(milliseconds: 220),
+    this.endScale = 0.92,
+    this.curve = Curves.easeInCubic,
+    this.autoStart = true,
+    this.onCompleted,
+  });
+
+  final Widget child;
+  final Duration duration;
+  final double endScale;
+  final Curve curve;
+  final bool autoStart;
+  final VoidCallback? onCompleted;
+
+  @override
+  Widget build(BuildContext context) {
+    return CoconutTransitionAnimation(
+      duration: duration,
+      beginOffset: Offset.zero,
+      endOffset: Offset.zero,
+      beginOpacity: 1,
+      endOpacity: 0,
+      beginScale: 1,
+      endScale: endScale,
+      curve: curve,
+      autoStart: autoStart,
+      onCompleted: onCompleted,
+      child: child,
+    );
+  }
+}

--- a/lib/src/animation/shake_animation.dart
+++ b/lib/src/animation/shake_animation.dart
@@ -42,6 +42,9 @@ class CoconutShakeAnimation extends StatefulWidget {
   /// Whether to start the shake animation automatically when the widget is built.
   final bool autoStart;
 
+  /// Delay before the shake animation starts automatically.
+  final Duration delay;
+
   const CoconutShakeAnimation({
     super.key,
     required this.child,
@@ -52,6 +55,7 @@ class CoconutShakeAnimation extends StatefulWidget {
     this.curve = Curves.linear,
     this.onCompleted,
     this.autoStart = false,
+    this.delay = Duration.zero,
   });
 
   @override
@@ -61,6 +65,7 @@ class CoconutShakeAnimation extends StatefulWidget {
 class CoconutShakeAnimationState extends State<CoconutShakeAnimation> with SingleTickerProviderStateMixin {
   late AnimationController _controller;
   late Animation<double> _offsetAnimation;
+  int _startToken = 0;
 
   @override
   void initState() {
@@ -89,12 +94,34 @@ class CoconutShakeAnimationState extends State<CoconutShakeAnimation> with Singl
     });
 
     if (widget.autoStart) {
-      WidgetsBinding.instance.addPostFrameCallback((_) => shake());
+      WidgetsBinding.instance.addPostFrameCallback((_) => _startWithDelay());
+    }
+  }
+
+  @override
+  void didUpdateWidget(covariant CoconutShakeAnimation oldWidget) {
+    super.didUpdateWidget(oldWidget);
+
+    if ((oldWidget.autoStart != widget.autoStart || oldWidget.delay != widget.delay) && widget.autoStart) {
+      _startWithDelay();
     }
   }
 
   void shake() {
     _controller.forward(from: 0.0);
+  }
+
+  void _startWithDelay() {
+    final token = ++_startToken;
+    if (widget.delay <= Duration.zero) {
+      shake();
+      return;
+    }
+
+    Future<void>.delayed(widget.delay, () {
+      if (!mounted || token != _startToken) return;
+      shake();
+    });
   }
 
   @override

--- a/lib/src/animation/slide_down_animation.dart
+++ b/lib/src/animation/slide_down_animation.dart
@@ -1,0 +1,38 @@
+import 'package:coconut_design_system/src/animation/transition_animation.dart';
+import 'package:flutter/material.dart';
+
+class CoconutSlideDownAnimation extends StatelessWidget {
+  const CoconutSlideDownAnimation({
+    super.key,
+    required this.child,
+    this.duration = const Duration(milliseconds: 280),
+    this.offset = const Offset(0, -24),
+    this.curve = Curves.easeOutCubic,
+    this.autoStart = true,
+    this.onCompleted,
+  });
+
+  final Widget child;
+  final Duration duration;
+  final Offset offset;
+  final Curve curve;
+  final bool autoStart;
+  final VoidCallback? onCompleted;
+
+  @override
+  Widget build(BuildContext context) {
+    return CoconutTransitionAnimation(
+      duration: duration,
+      beginOffset: offset,
+      endOffset: Offset.zero,
+      beginOpacity: 0,
+      endOpacity: 1,
+      beginScale: 1,
+      endScale: 1,
+      curve: curve,
+      autoStart: autoStart,
+      onCompleted: onCompleted,
+      child: child,
+    );
+  }
+}

--- a/lib/src/animation/slide_down_animation.dart
+++ b/lib/src/animation/slide_down_animation.dart
@@ -6,6 +6,7 @@ class CoconutSlideDownAnimation extends StatelessWidget {
     super.key,
     required this.child,
     this.duration = const Duration(milliseconds: 280),
+    this.delay = Duration.zero,
     this.offset = const Offset(0, -24),
     this.curve = Curves.easeOutCubic,
     this.autoStart = true,
@@ -14,6 +15,7 @@ class CoconutSlideDownAnimation extends StatelessWidget {
 
   final Widget child;
   final Duration duration;
+  final Duration delay;
   final Offset offset;
   final Curve curve;
   final bool autoStart;
@@ -23,6 +25,7 @@ class CoconutSlideDownAnimation extends StatelessWidget {
   Widget build(BuildContext context) {
     return CoconutTransitionAnimation(
       duration: duration,
+      delay: delay,
       beginOffset: offset,
       endOffset: Offset.zero,
       beginOpacity: 0,

--- a/lib/src/animation/slide_left_animation.dart
+++ b/lib/src/animation/slide_left_animation.dart
@@ -1,0 +1,38 @@
+import 'package:coconut_design_system/src/animation/transition_animation.dart';
+import 'package:flutter/material.dart';
+
+class CoconutSlideLeftAnimation extends StatelessWidget {
+  const CoconutSlideLeftAnimation({
+    super.key,
+    required this.child,
+    this.duration = const Duration(milliseconds: 280),
+    this.offset = const Offset(24, 0),
+    this.curve = Curves.easeOutCubic,
+    this.autoStart = true,
+    this.onCompleted,
+  });
+
+  final Widget child;
+  final Duration duration;
+  final Offset offset;
+  final Curve curve;
+  final bool autoStart;
+  final VoidCallback? onCompleted;
+
+  @override
+  Widget build(BuildContext context) {
+    return CoconutTransitionAnimation(
+      duration: duration,
+      beginOffset: offset,
+      endOffset: Offset.zero,
+      beginOpacity: 0,
+      endOpacity: 1,
+      beginScale: 1,
+      endScale: 1,
+      curve: curve,
+      autoStart: autoStart,
+      onCompleted: onCompleted,
+      child: child,
+    );
+  }
+}

--- a/lib/src/animation/slide_left_animation.dart
+++ b/lib/src/animation/slide_left_animation.dart
@@ -6,6 +6,7 @@ class CoconutSlideLeftAnimation extends StatelessWidget {
     super.key,
     required this.child,
     this.duration = const Duration(milliseconds: 280),
+    this.delay = Duration.zero,
     this.offset = const Offset(24, 0),
     this.curve = Curves.easeOutCubic,
     this.autoStart = true,
@@ -14,6 +15,7 @@ class CoconutSlideLeftAnimation extends StatelessWidget {
 
   final Widget child;
   final Duration duration;
+  final Duration delay;
   final Offset offset;
   final Curve curve;
   final bool autoStart;
@@ -23,6 +25,7 @@ class CoconutSlideLeftAnimation extends StatelessWidget {
   Widget build(BuildContext context) {
     return CoconutTransitionAnimation(
       duration: duration,
+      delay: delay,
       beginOffset: offset,
       endOffset: Offset.zero,
       beginOpacity: 0,

--- a/lib/src/animation/slide_right_animation.dart
+++ b/lib/src/animation/slide_right_animation.dart
@@ -1,0 +1,38 @@
+import 'package:coconut_design_system/src/animation/transition_animation.dart';
+import 'package:flutter/material.dart';
+
+class CoconutSlideRightAnimation extends StatelessWidget {
+  const CoconutSlideRightAnimation({
+    super.key,
+    required this.child,
+    this.duration = const Duration(milliseconds: 280),
+    this.offset = const Offset(-24, 0),
+    this.curve = Curves.easeOutCubic,
+    this.autoStart = true,
+    this.onCompleted,
+  });
+
+  final Widget child;
+  final Duration duration;
+  final Offset offset;
+  final Curve curve;
+  final bool autoStart;
+  final VoidCallback? onCompleted;
+
+  @override
+  Widget build(BuildContext context) {
+    return CoconutTransitionAnimation(
+      duration: duration,
+      beginOffset: offset,
+      endOffset: Offset.zero,
+      beginOpacity: 0,
+      endOpacity: 1,
+      beginScale: 1,
+      endScale: 1,
+      curve: curve,
+      autoStart: autoStart,
+      onCompleted: onCompleted,
+      child: child,
+    );
+  }
+}

--- a/lib/src/animation/slide_right_animation.dart
+++ b/lib/src/animation/slide_right_animation.dart
@@ -6,6 +6,7 @@ class CoconutSlideRightAnimation extends StatelessWidget {
     super.key,
     required this.child,
     this.duration = const Duration(milliseconds: 280),
+    this.delay = Duration.zero,
     this.offset = const Offset(-24, 0),
     this.curve = Curves.easeOutCubic,
     this.autoStart = true,
@@ -14,6 +15,7 @@ class CoconutSlideRightAnimation extends StatelessWidget {
 
   final Widget child;
   final Duration duration;
+  final Duration delay;
   final Offset offset;
   final Curve curve;
   final bool autoStart;
@@ -23,6 +25,7 @@ class CoconutSlideRightAnimation extends StatelessWidget {
   Widget build(BuildContext context) {
     return CoconutTransitionAnimation(
       duration: duration,
+      delay: delay,
       beginOffset: offset,
       endOffset: Offset.zero,
       beginOpacity: 0,

--- a/lib/src/animation/slide_up_animation.dart
+++ b/lib/src/animation/slide_up_animation.dart
@@ -1,0 +1,38 @@
+import 'package:coconut_design_system/src/animation/transition_animation.dart';
+import 'package:flutter/material.dart';
+
+class CoconutSlideUpAnimation extends StatelessWidget {
+  const CoconutSlideUpAnimation({
+    super.key,
+    required this.child,
+    this.duration = const Duration(milliseconds: 280),
+    this.offset = const Offset(0, 24),
+    this.curve = Curves.easeOutCubic,
+    this.autoStart = true,
+    this.onCompleted,
+  });
+
+  final Widget child;
+  final Duration duration;
+  final Offset offset;
+  final Curve curve;
+  final bool autoStart;
+  final VoidCallback? onCompleted;
+
+  @override
+  Widget build(BuildContext context) {
+    return CoconutTransitionAnimation(
+      duration: duration,
+      beginOffset: offset,
+      endOffset: Offset.zero,
+      beginOpacity: 0,
+      endOpacity: 1,
+      beginScale: 1,
+      endScale: 1,
+      curve: curve,
+      autoStart: autoStart,
+      onCompleted: onCompleted,
+      child: child,
+    );
+  }
+}

--- a/lib/src/animation/slide_up_animation.dart
+++ b/lib/src/animation/slide_up_animation.dart
@@ -6,6 +6,7 @@ class CoconutSlideUpAnimation extends StatelessWidget {
     super.key,
     required this.child,
     this.duration = const Duration(milliseconds: 280),
+    this.delay = Duration.zero,
     this.offset = const Offset(0, 24),
     this.curve = Curves.easeOutCubic,
     this.autoStart = true,
@@ -14,6 +15,7 @@ class CoconutSlideUpAnimation extends StatelessWidget {
 
   final Widget child;
   final Duration duration;
+  final Duration delay;
   final Offset offset;
   final Curve curve;
   final bool autoStart;
@@ -23,6 +25,7 @@ class CoconutSlideUpAnimation extends StatelessWidget {
   Widget build(BuildContext context) {
     return CoconutTransitionAnimation(
       duration: duration,
+      delay: delay,
       beginOffset: offset,
       endOffset: Offset.zero,
       beginOpacity: 0,

--- a/lib/src/animation/transition_animation.dart
+++ b/lib/src/animation/transition_animation.dart
@@ -12,6 +12,7 @@ class CoconutTransitionAnimation extends StatefulWidget {
     required this.endScale,
     required this.curve,
     required this.duration,
+    this.delay = Duration.zero,
     this.alignment = Alignment.center,
     this.autoStart = true,
     this.onCompleted,
@@ -26,6 +27,7 @@ class CoconutTransitionAnimation extends StatefulWidget {
   final double endScale;
   final Curve curve;
   final Duration duration;
+  final Duration delay;
   final Alignment alignment;
   final bool autoStart;
   final VoidCallback? onCompleted;
@@ -41,6 +43,7 @@ class _CoconutTransitionAnimationState extends State<CoconutTransitionAnimation>
   late final Animation<Offset> _offsetAnimation;
   late final Animation<double> _opacityAnimation;
   late final Animation<double> _scaleAnimation;
+  int _startToken = 0;
 
   @override
   void initState() {
@@ -74,8 +77,31 @@ class _CoconutTransitionAnimationState extends State<CoconutTransitionAnimation>
     });
 
     if (widget.autoStart) {
-      _controller.forward();
+      _startAnimationWithDelay();
     }
+  }
+
+  @override
+  void didUpdateWidget(covariant CoconutTransitionAnimation oldWidget) {
+    super.didUpdateWidget(oldWidget);
+
+    if ((oldWidget.autoStart != widget.autoStart || oldWidget.delay != widget.delay) && widget.autoStart) {
+      _startAnimationWithDelay();
+    }
+  }
+
+  void _startAnimationWithDelay() {
+    final token = ++_startToken;
+
+    if (widget.delay <= Duration.zero) {
+      _controller.forward(from: 0);
+      return;
+    }
+
+    Future<void>.delayed(widget.delay, () {
+      if (!mounted || token != _startToken) return;
+      _controller.forward(from: 0);
+    });
   }
 
   @override

--- a/lib/src/animation/transition_animation.dart
+++ b/lib/src/animation/transition_animation.dart
@@ -1,0 +1,107 @@
+import 'package:flutter/material.dart';
+
+class CoconutTransitionAnimation extends StatefulWidget {
+  const CoconutTransitionAnimation({
+    super.key,
+    required this.child,
+    required this.beginOffset,
+    required this.endOffset,
+    required this.beginOpacity,
+    required this.endOpacity,
+    required this.beginScale,
+    required this.endScale,
+    required this.curve,
+    required this.duration,
+    this.alignment = Alignment.center,
+    this.autoStart = true,
+    this.onCompleted,
+  });
+
+  final Widget child;
+  final Offset beginOffset;
+  final Offset endOffset;
+  final double beginOpacity;
+  final double endOpacity;
+  final double beginScale;
+  final double endScale;
+  final Curve curve;
+  final Duration duration;
+  final Alignment alignment;
+  final bool autoStart;
+  final VoidCallback? onCompleted;
+
+  @override
+  State<CoconutTransitionAnimation> createState() => _CoconutTransitionAnimationState();
+}
+
+class _CoconutTransitionAnimationState extends State<CoconutTransitionAnimation>
+    with SingleTickerProviderStateMixin {
+  late final AnimationController _controller;
+  late final Animation<double> _animation;
+  late final Animation<Offset> _offsetAnimation;
+  late final Animation<double> _opacityAnimation;
+  late final Animation<double> _scaleAnimation;
+
+  @override
+  void initState() {
+    super.initState();
+    _controller = AnimationController(
+      vsync: this,
+      duration: widget.duration,
+    );
+
+    _animation = CurvedAnimation(
+      parent: _controller,
+      curve: widget.curve,
+    );
+    _offsetAnimation = Tween<Offset>(
+      begin: widget.beginOffset,
+      end: widget.endOffset,
+    ).animate(_animation);
+    _opacityAnimation = Tween<double>(
+      begin: widget.beginOpacity,
+      end: widget.endOpacity,
+    ).animate(_animation);
+    _scaleAnimation = Tween<double>(
+      begin: widget.beginScale,
+      end: widget.endScale,
+    ).animate(_animation);
+
+    _controller.addStatusListener((status) {
+      if (status == AnimationStatus.completed) {
+        widget.onCompleted?.call();
+      }
+    });
+
+    if (widget.autoStart) {
+      _controller.forward();
+    }
+  }
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return AnimatedBuilder(
+      animation: _controller,
+      child: widget.child,
+      builder: (context, child) {
+        return Opacity(
+          opacity: _opacityAnimation.value.clamp(0.0, 1.0),
+          child: Transform.translate(
+            offset: _offsetAnimation.value,
+            child: Transform.scale(
+              alignment: widget.alignment,
+              scale: _scaleAnimation.value,
+              child: child,
+            ),
+          ),
+        );
+      },
+    );
+  }
+}

--- a/lib/src/animation/typewriter_animation.dart
+++ b/lib/src/animation/typewriter_animation.dart
@@ -22,6 +22,7 @@ class CoconutTypewriterAnimation extends StatefulWidget {
     this.maxLines,
     this.overflow,
     this.duration = const Duration(milliseconds: 800),
+    this.delay = Duration.zero,
     this.curve = Curves.linear,
     this.autoStart = true,
     this.onCompleted,
@@ -45,6 +46,9 @@ class CoconutTypewriterAnimation extends StatefulWidget {
   /// The total duration required to reveal the full text.
   final Duration duration;
 
+  /// Delay before the animation starts automatically.
+  final Duration delay;
+
   /// The animation curve used for the text reveal progression.
   final Curve curve;
 
@@ -62,6 +66,7 @@ class _CoconutTypewriterAnimationState extends State<CoconutTypewriterAnimation>
     with SingleTickerProviderStateMixin {
   late final AnimationController _controller;
   late final Animation<double> _progressAnimation;
+  int _startToken = 0;
 
   @override
   void initState() {
@@ -84,7 +89,7 @@ class _CoconutTypewriterAnimationState extends State<CoconutTypewriterAnimation>
     if (widget.autoStart) {
       WidgetsBinding.instance.addPostFrameCallback((_) {
         if (mounted) {
-          start();
+          _startWithDelay();
         }
       });
     }
@@ -99,13 +104,26 @@ class _CoconutTypewriterAnimationState extends State<CoconutTypewriterAnimation>
     }
 
     if (oldWidget.text != widget.text && widget.autoStart) {
-      start();
+      _startWithDelay();
     }
   }
 
   /// Restarts the typewriter animation from the beginning.
   void start() {
     _controller.forward(from: 0);
+  }
+
+  void _startWithDelay() {
+    final token = ++_startToken;
+    if (widget.delay <= Duration.zero) {
+      start();
+      return;
+    }
+
+    Future<void>.delayed(widget.delay, () {
+      if (!mounted || token != _startToken) return;
+      start();
+    });
   }
 
   @override

--- a/lib/src/animation/typewriter_animation.dart
+++ b/lib/src/animation/typewriter_animation.dart
@@ -1,0 +1,135 @@
+import 'package:flutter/material.dart';
+
+/// A text animation widget that reveals characters one by one.
+///
+/// This widget is useful for typewriter-style introductions, onboarding text,
+/// or small motion accents in content areas.
+///
+/// Example usage:
+/// ```dart
+/// CoconutTypewriterAnimation(
+///   text: 'Hello Coconut',
+///   textStyle: TextStyle(fontSize: 16),
+///   autoStart: true,
+/// )
+/// ```
+class CoconutTypewriterAnimation extends StatefulWidget {
+  const CoconutTypewriterAnimation({
+    super.key,
+    required this.text,
+    this.textStyle,
+    this.textAlign,
+    this.maxLines,
+    this.overflow,
+    this.duration = const Duration(milliseconds: 800),
+    this.curve = Curves.linear,
+    this.autoStart = true,
+    this.onCompleted,
+  });
+
+  /// The full text to reveal progressively.
+  final String text;
+
+  /// The style applied to the animated text.
+  final TextStyle? textStyle;
+
+  /// How the text should be aligned horizontally.
+  final TextAlign? textAlign;
+
+  /// The maximum number of lines for the text.
+  final int? maxLines;
+
+  /// The overflow behavior of the text.
+  final TextOverflow? overflow;
+
+  /// The total duration required to reveal the full text.
+  final Duration duration;
+
+  /// The animation curve used for the text reveal progression.
+  final Curve curve;
+
+  /// Whether to start the animation automatically after the first frame.
+  final bool autoStart;
+
+  /// Callback triggered when the animation completes.
+  final VoidCallback? onCompleted;
+
+  @override
+  State<CoconutTypewriterAnimation> createState() => _CoconutTypewriterAnimationState();
+}
+
+class _CoconutTypewriterAnimationState extends State<CoconutTypewriterAnimation>
+    with SingleTickerProviderStateMixin {
+  late final AnimationController _controller;
+  late final Animation<double> _progressAnimation;
+
+  @override
+  void initState() {
+    super.initState();
+    _controller = AnimationController(
+      vsync: this,
+      duration: widget.duration,
+    );
+    _progressAnimation = CurvedAnimation(
+      parent: _controller,
+      curve: widget.curve,
+    );
+
+    _controller.addStatusListener((status) {
+      if (status == AnimationStatus.completed) {
+        widget.onCompleted?.call();
+      }
+    });
+
+    if (widget.autoStart) {
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        if (mounted) {
+          start();
+        }
+      });
+    }
+  }
+
+  @override
+  void didUpdateWidget(covariant CoconutTypewriterAnimation oldWidget) {
+    super.didUpdateWidget(oldWidget);
+
+    if (oldWidget.duration != widget.duration) {
+      _controller.duration = widget.duration;
+    }
+
+    if (oldWidget.text != widget.text && widget.autoStart) {
+      start();
+    }
+  }
+
+  /// Restarts the typewriter animation from the beginning.
+  void start() {
+    _controller.forward(from: 0);
+  }
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return AnimatedBuilder(
+      animation: _progressAnimation,
+      builder: (context, child) {
+        final visibleLength = (widget.text.characters.length * _progressAnimation.value).round();
+        final visibleText = widget.text.characters.take(visibleLength).toString();
+
+        return Text(
+          visibleText,
+          style: widget.textStyle,
+          textAlign: widget.textAlign,
+          maxLines: widget.maxLines,
+          overflow: widget.overflow,
+        );
+      },
+    );
+  }
+}

--- a/lib/src/animation/zoom_in_animation.dart
+++ b/lib/src/animation/zoom_in_animation.dart
@@ -1,0 +1,38 @@
+import 'package:coconut_design_system/src/animation/transition_animation.dart';
+import 'package:flutter/material.dart';
+
+class CoconutZoomInAnimation extends StatelessWidget {
+  const CoconutZoomInAnimation({
+    super.key,
+    required this.child,
+    this.duration = const Duration(milliseconds: 260),
+    this.beginScale = 0.72,
+    this.curve = Curves.easeOutBack,
+    this.autoStart = true,
+    this.onCompleted,
+  });
+
+  final Widget child;
+  final Duration duration;
+  final double beginScale;
+  final Curve curve;
+  final bool autoStart;
+  final VoidCallback? onCompleted;
+
+  @override
+  Widget build(BuildContext context) {
+    return CoconutTransitionAnimation(
+      duration: duration,
+      beginOffset: Offset.zero,
+      endOffset: Offset.zero,
+      beginOpacity: 0,
+      endOpacity: 1,
+      beginScale: beginScale,
+      endScale: 1,
+      curve: curve,
+      autoStart: autoStart,
+      onCompleted: onCompleted,
+      child: child,
+    );
+  }
+}

--- a/lib/src/animation/zoom_in_animation.dart
+++ b/lib/src/animation/zoom_in_animation.dart
@@ -6,6 +6,7 @@ class CoconutZoomInAnimation extends StatelessWidget {
     super.key,
     required this.child,
     this.duration = const Duration(milliseconds: 260),
+    this.delay = Duration.zero,
     this.beginScale = 0.72,
     this.curve = Curves.easeOutBack,
     this.autoStart = true,
@@ -14,6 +15,7 @@ class CoconutZoomInAnimation extends StatelessWidget {
 
   final Widget child;
   final Duration duration;
+  final Duration delay;
   final double beginScale;
   final Curve curve;
   final bool autoStart;
@@ -23,6 +25,7 @@ class CoconutZoomInAnimation extends StatelessWidget {
   Widget build(BuildContext context) {
     return CoconutTransitionAnimation(
       duration: duration,
+      delay: delay,
       beginOffset: Offset.zero,
       endOffset: Offset.zero,
       beginOpacity: 0,

--- a/lib/src/animation/zoom_out_animation.dart
+++ b/lib/src/animation/zoom_out_animation.dart
@@ -6,6 +6,7 @@ class CoconutZoomOutAnimation extends StatelessWidget {
     super.key,
     required this.child,
     this.duration = const Duration(milliseconds: 220),
+    this.delay = Duration.zero,
     this.endScale = 0.64,
     this.curve = Curves.easeInBack,
     this.autoStart = true,
@@ -14,6 +15,7 @@ class CoconutZoomOutAnimation extends StatelessWidget {
 
   final Widget child;
   final Duration duration;
+  final Duration delay;
   final double endScale;
   final Curve curve;
   final bool autoStart;
@@ -23,6 +25,7 @@ class CoconutZoomOutAnimation extends StatelessWidget {
   Widget build(BuildContext context) {
     return CoconutTransitionAnimation(
       duration: duration,
+      delay: delay,
       beginOffset: Offset.zero,
       endOffset: Offset.zero,
       beginOpacity: 1,

--- a/lib/src/animation/zoom_out_animation.dart
+++ b/lib/src/animation/zoom_out_animation.dart
@@ -1,0 +1,38 @@
+import 'package:coconut_design_system/src/animation/transition_animation.dart';
+import 'package:flutter/material.dart';
+
+class CoconutZoomOutAnimation extends StatelessWidget {
+  const CoconutZoomOutAnimation({
+    super.key,
+    required this.child,
+    this.duration = const Duration(milliseconds: 220),
+    this.endScale = 0.64,
+    this.curve = Curves.easeInBack,
+    this.autoStart = true,
+    this.onCompleted,
+  });
+
+  final Widget child;
+  final Duration duration;
+  final double endScale;
+  final Curve curve;
+  final bool autoStart;
+  final VoidCallback? onCompleted;
+
+  @override
+  Widget build(BuildContext context) {
+    return CoconutTransitionAnimation(
+      duration: duration,
+      beginOffset: Offset.zero,
+      endOffset: Offset.zero,
+      beginOpacity: 1,
+      endOpacity: 0,
+      beginScale: 1,
+      endScale: endScale,
+      curve: curve,
+      autoStart: autoStart,
+      onCompleted: onCompleted,
+      child: child,
+    );
+  }
+}

--- a/lib/src/components/inputs/option-picker.dart
+++ b/lib/src/components/inputs/option-picker.dart
@@ -316,13 +316,15 @@ class CoconutOptionPicker extends StatelessWidget {
           crossAxisAlignment: CrossAxisAlignment.center,
           children: [
             if (coconutOptionStateEnum != CoconutOptionStateEnum.normal && guideText != null) ...[
-              Padding(
-                padding: const EdgeInsets.only(top: 4, left: 2),
-                child: Align(
-                  alignment: Alignment.centerLeft,
-                  child: Text(
-                    guideText!,
-                    style: resolveGuideStyle,
+              Expanded(
+                child: Padding(
+                  padding: const EdgeInsets.only(top: 4, left: 2),
+                  child: Align(
+                    alignment: Alignment.centerLeft,
+                    child: Text(
+                      guideText!,
+                      style: resolveGuideStyle,
+                    ),
                   ),
                 ),
               )

--- a/lib/src/components/inputs/option-picker.dart
+++ b/lib/src/components/inputs/option-picker.dart
@@ -50,6 +50,8 @@ class CoconutOptionPicker extends StatelessWidget {
   /// - [inlineWidgets] are rendered to the right of [text] inside the same
   ///   horizontal scroll area.
   /// - [inlineSpacing] sets the horizontal gap between [text] and [inlineWidgets].
+  /// - [enableTextWrap] allows the main content to wrap onto multiple lines
+  ///   instead of scrolling horizontally.
   /// - [subWidget] displays an additional widget below the divider on the trailing side.
   ///
   /// Example usage:
@@ -91,6 +93,7 @@ class CoconutOptionPicker extends StatelessWidget {
     this.coconutOptionStateEnum = CoconutOptionStateEnum.normal,
     this.inlineWidgets = const [],
     this.inlineSpacing = 8,
+    this.enableTextWrap = false,
   });
 
   /// The primary text displayed in the picker row.
@@ -174,6 +177,12 @@ class CoconutOptionPicker extends StatelessWidget {
   /// Defaults to `8.0` pixels.
   final double inlineSpacing;
 
+  /// Whether the main content should wrap onto multiple lines.
+  ///
+  /// If `false`, the content scrolls horizontally.
+  /// If `true`, the content wraps instead of scrolling.
+  final bool enableTextWrap;
+
   @override
   Widget build(BuildContext context) {
     final brightness = Theme.of(context).brightness;
@@ -208,6 +217,22 @@ class CoconutOptionPicker extends StatelessWidget {
     final resolvedLabelColor = labelColor ?? CoconutColors.gray500;
     final resolvedLabelStyle =
         labelStyle ?? CoconutTypography.body3_12.setColor(resolvedLabelColor);
+    final List<InlineSpan> wrappedContentSpans = [
+      TextSpan(
+        text: text,
+        style: resolvedTextStyle,
+      ),
+      for (final widget in inlineWidgets) ...[
+        WidgetSpan(
+          alignment: PlaceholderAlignment.middle,
+          child: SizedBox(width: inlineSpacing),
+        ),
+        WidgetSpan(
+          alignment: PlaceholderAlignment.middle,
+          child: widget,
+        ),
+      ],
+    ];
     return Column(
       mainAxisSize: MainAxisSize.min,
       children: [
@@ -235,25 +260,30 @@ class CoconutOptionPicker extends StatelessWidget {
                 child: Row(
                   children: [
                     Expanded(
-                      child: SingleChildScrollView(
-                        scrollDirection: Axis.horizontal,
-                        // Scroll the full inline content, including the leading text.
-                        child: Row(
-                          mainAxisSize: MainAxisSize.min,
-                          children: [
-                            Text(
-                              text,
-                              maxLines: 1,
-                              softWrap: false,
-                              style: resolvedTextStyle,
+                      child: enableTextWrap
+                          ? Text.rich(
+                              TextSpan(children: wrappedContentSpans),
+                              softWrap: true,
+                            )
+                          : SingleChildScrollView(
+                              scrollDirection: Axis.horizontal,
+                              // Scroll the full inline content, including the leading text.
+                              child: Row(
+                                mainAxisSize: MainAxisSize.min,
+                                children: [
+                                  Text(
+                                    text,
+                                    maxLines: 1,
+                                    softWrap: false,
+                                    style: resolvedTextStyle,
+                                  ),
+                                  for (final widget in inlineWidgets) ...[
+                                    SizedBox(width: inlineSpacing),
+                                    widget,
+                                  ],
+                                ],
+                              ),
                             ),
-                            for (final widget in inlineWidgets) ...[
-                              SizedBox(width: inlineSpacing),
-                              widget,
-                            ],
-                          ],
-                        ),
-                      ),
                     ),
                     const SizedBox(width: 8),
                     SvgPicture.asset(

--- a/lib/src/components/inputs/option-picker.dart
+++ b/lib/src/components/inputs/option-picker.dart
@@ -26,6 +26,7 @@ enum CoconutOptionStateEnum {
 /// - A divider below the tappable row
 /// - Semantic visual states via [coconutOptionStateEnum]
 /// - An optional [guideText] shown for warning and error states
+/// - An optional [subWidget] shown below the divider on the right side
 ///
 /// The main content row scrolls horizontally so that long text and inline widgets
 /// remain accessible without wrapping.
@@ -49,6 +50,7 @@ class CoconutOptionPicker extends StatelessWidget {
   /// - [inlineWidgets] are rendered to the right of [text] inside the same
   ///   horizontal scroll area.
   /// - [inlineSpacing] sets the horizontal gap between [text] and [inlineWidgets].
+  /// - [subWidget] displays an additional widget below the divider on the trailing side.
   ///
   /// Example usage:
   /// ```dart
@@ -73,7 +75,7 @@ class CoconutOptionPicker extends StatelessWidget {
     this.enabled = true,
     this.label,
     this.guideText,
-    this.inlineWidget,
+    this.subWidget,
     this.padding,
     this.textStyle,
     this.labelStyle,
@@ -107,12 +109,11 @@ class CoconutOptionPicker extends StatelessWidget {
   /// [CoconutOptionStateEnum.normal].
   final String? guideText;
 
-  /// The inline widget displayed to the right of the main text.
+  /// The supplementary widget displayed below the divider on the trailing side.
   ///
-  /// This widget is rendered inline with the text inside the same horizontal
-  /// scroll area, making it suitable for elements such as chips, tags,
-  /// or badges.
-  final Widget? inlineWidget;
+  /// This widget is commonly used for secondary actions or contextual content
+  /// that should be visually separated from the main picker row.
+  final Widget? subWidget;
 
   /// Callback function triggered when the picker row is tapped.
   final VoidCallback? onTap;
@@ -296,8 +297,8 @@ class CoconutOptionPicker extends StatelessWidget {
               // for using left side area
               Container(),
             ],
-            if (inlineWidget != null) ...[
-              Padding(padding: const EdgeInsets.only(top: 4, left: 2), child: inlineWidget!),
+            if (subWidget != null) ...[
+              Padding(padding: const EdgeInsets.only(top: 4, left: 2), child: subWidget!),
             ],
           ],
         )

--- a/lib/src/components/inputs/option-picker.dart
+++ b/lib/src/components/inputs/option-picker.dart
@@ -73,6 +73,7 @@ class CoconutOptionPicker extends StatelessWidget {
     this.enabled = true,
     this.label,
     this.guideText,
+    this.inlineWidget,
     this.padding,
     this.textStyle,
     this.labelStyle,
@@ -105,6 +106,13 @@ class CoconutOptionPicker extends StatelessWidget {
   /// This text is shown only when [coconutOptionStateEnum] is not
   /// [CoconutOptionStateEnum.normal].
   final String? guideText;
+
+  /// The inline widget displayed to the right of the main text.
+  ///
+  /// This widget is rendered inline with the text inside the same horizontal
+  /// scroll area, making it suitable for elements such as chips, tags,
+  /// or badges.
+  final Widget? inlineWidget;
 
   /// Callback function triggered when the picker row is tapped.
   final VoidCallback? onTap;
@@ -268,18 +276,31 @@ class CoconutOptionPicker extends StatelessWidget {
             thickness: 1,
             color: resolvedDividerColor,
           ),
-        if (coconutOptionStateEnum != CoconutOptionStateEnum.normal && guideText != null) ...[
-          Padding(
-            padding: const EdgeInsets.only(top: 4, left: 2),
-            child: Align(
-              alignment: Alignment.centerLeft,
-              child: Text(
-                guideText!,
-                style: resolveGuideStyle,
-              ),
-            ),
-          )
-        ]
+        Row(
+          mainAxisAlignment: MainAxisAlignment.spaceBetween,
+          crossAxisAlignment: CrossAxisAlignment.center,
+          children: [
+            if (coconutOptionStateEnum != CoconutOptionStateEnum.normal && guideText != null) ...[
+              Padding(
+                padding: const EdgeInsets.only(top: 4, left: 2),
+                child: Align(
+                  alignment: Alignment.centerLeft,
+                  child: Text(
+                    guideText!,
+                    style: resolveGuideStyle,
+                  ),
+                ),
+              )
+            ],
+            if (coconutOptionStateEnum == CoconutOptionStateEnum.normal) ...[
+              // for using left side area
+              Container(),
+            ],
+            if (inlineWidget != null) ...[
+              Padding(padding: const EdgeInsets.only(top: 4, left: 2), child: inlineWidget!),
+            ],
+          ],
+        )
       ],
     );
   }

--- a/lib/src/components/inputs/option-picker.dart
+++ b/lib/src/components/inputs/option-picker.dart
@@ -1,0 +1,286 @@
+import 'package:coconut_design_system/coconut_design_system.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_svg/flutter_svg.dart';
+
+/// Defines the visual state of [CoconutOptionPicker].
+///
+/// - [normal] uses the default neutral styling.
+/// - [warning] highlights supporting elements with a warning color.
+/// - [error] highlights supporting elements with an error color.
+enum CoconutOptionStateEnum {
+  normal,
+  warning,
+  error,
+}
+
+/// A tappable option field that displays a selected value with an optional label,
+/// inline widgets, and a trailing chevron icon.
+///
+/// This widget is useful when you want a compact "selection trigger" UI that
+/// opens a custom action such as a bottom sheet, dialog, or route when tapped.
+///
+/// The picker supports:
+/// - An optional [label] above the main row
+/// - A primary [text] value
+/// - Optional [inlineWidgets] placed to the right of the text
+/// - A divider below the tappable row
+/// - Semantic visual states via [coconutOptionStateEnum]
+/// - An optional [guideText] shown for warning and error states
+///
+/// The main content row scrolls horizontally so that long text and inline widgets
+/// remain accessible without wrapping.
+class CoconutOptionPicker extends StatelessWidget {
+  /// Creates a `CoconutOptionPicker` widget.
+  ///
+  /// - [text] is the primary value displayed inside the picker row.
+  /// - [onTap] is called when the tappable row is pressed.
+  /// - [enabled] controls whether the row is interactive.
+  /// - [label] displays a caption above the picker row.
+  /// - [guideText] displays a helper message below the divider when the state is
+  ///   [CoconutOptionStateEnum.warning] or [CoconutOptionStateEnum.error].
+  /// - [padding] customizes the inner spacing of the tappable row.
+  /// - [textStyle], [labelStyle], and [guideStyle] override the default text styles.
+  /// - [textColor], [labelColor], [iconColor], [dividerColor], and [guideTextColor]
+  ///   customize colors when not overridden by the semantic state styling.
+  /// - [iconSize] sets the size of the trailing chevron icon.
+  /// - [showDivider] toggles the divider below the row.
+  /// - [borderRadius] applies the top-left and top-right ripple radius.
+  /// - [coconutOptionStateEnum] controls semantic styling for warning and error states.
+  /// - [inlineWidgets] are rendered to the right of [text] inside the same
+  ///   horizontal scroll area.
+  /// - [inlineSpacing] sets the horizontal gap between [text] and [inlineWidgets].
+  ///
+  /// Example usage:
+  /// ```dart
+  /// CoconutOptionPicker(
+  ///   label: 'Selected UTXO',
+  ///   text: '0.1 BTC',
+  ///   inlineWidgets: const [
+  ///     CoconutChip(
+  ///       label: '#non-kyc',
+  ///       color: CoconutColors.yellow,
+  ///     ),
+  ///   ],
+  ///   onTap: () {
+  ///     print('Open option picker action');
+  ///   },
+  /// )
+  /// ```
+  const CoconutOptionPicker({
+    super.key,
+    required this.text,
+    required this.onTap,
+    this.enabled = true,
+    this.label,
+    this.guideText,
+    this.padding,
+    this.textStyle,
+    this.labelStyle,
+    this.guideStyle,
+    this.textColor,
+    this.labelColor,
+    this.iconColor,
+    this.iconSize = 24,
+    this.showDivider = true,
+    this.dividerColor,
+    this.guideTextColor,
+    this.borderRadius,
+    this.coconutOptionStateEnum = CoconutOptionStateEnum.normal,
+    this.inlineWidgets = const [],
+    this.inlineSpacing = 8,
+  });
+
+  /// The primary text displayed in the picker row.
+  ///
+  /// This usually represents the currently selected value.
+  final String text;
+
+  /// An optional label displayed above the picker row.
+  ///
+  /// This is commonly used as a field title or caption.
+  final String? label;
+
+  /// An optional helper message displayed below the divider.
+  ///
+  /// This text is shown only when [coconutOptionStateEnum] is not
+  /// [CoconutOptionStateEnum.normal].
+  final String? guideText;
+
+  /// Callback function triggered when the picker row is tapped.
+  final VoidCallback? onTap;
+
+  /// Whether the picker is interactive.
+  ///
+  /// If `false`, the widget uses disabled text and icon colors and disables tap handling.
+  final bool enabled;
+
+  /// Padding applied inside the tappable picker row.
+  final EdgeInsetsGeometry? padding;
+
+  /// Custom text style for the main [text].
+  final TextStyle? textStyle;
+
+  /// Custom text style for the [label].
+  final TextStyle? labelStyle;
+
+  /// Custom text style for the [guideText].
+  final TextStyle? guideStyle;
+
+  /// Custom color for the main [text].
+  final Color? textColor;
+
+  /// Custom color for the [label].
+  final Color? labelColor;
+
+  /// Custom color for the trailing chevron icon.
+  final Color? iconColor;
+
+  /// The size of the trailing chevron icon.
+  ///
+  /// Defaults to `24.0` pixels.
+  final double iconSize;
+
+  /// Whether to show the divider below the picker row.
+  final bool showDivider;
+
+  /// Custom color for the divider.
+  final Color? dividerColor;
+
+  /// Custom color for the [guideText].
+  final Color? guideTextColor;
+
+  /// The top-left and top-right border radius used by the ripple effect.
+  final double? borderRadius;
+
+  /// The semantic visual state of the picker.
+  final CoconutOptionStateEnum coconutOptionStateEnum;
+
+  /// Additional widgets displayed to the right of [text].
+  ///
+  /// These widgets are included in the same horizontal scroll area as the main text.
+  final List<Widget> inlineWidgets;
+
+  /// The horizontal spacing between [text] and each item in [inlineWidgets].
+  ///
+  /// Defaults to `8.0` pixels.
+  final double inlineSpacing;
+
+  @override
+  Widget build(BuildContext context) {
+    final brightness = Theme.of(context).brightness;
+
+    // Applies semantic state colors for warning and error presentations.
+    Color getColorByState(Color defaultColor) {
+      return coconutOptionStateEnum == CoconutOptionStateEnum.normal
+          ? defaultColor
+          : coconutOptionStateEnum == CoconutOptionStateEnum.warning
+              ? CoconutColors.yellow
+              : CoconutColors.hotPink;
+    }
+
+    final resolvedTextColor = enabled
+        ? (textColor ?? CoconutColors.onBlack(brightness))
+        : CoconutColors.onGray500(brightness);
+    final resolvedIconColor = getColorByState(enabled
+        ? (iconColor ?? CoconutColors.onGray500(brightness))
+        : CoconutColors.onGray500(brightness));
+    final resolvedDividerColor =
+        getColorByState(dividerColor ?? CoconutColors.onGray800(brightness));
+    final resolvedTextStyle =
+        textStyle ?? CoconutTypography.heading4_18.setColor(resolvedTextColor);
+    final resolvedGuideTextColor =
+        getColorByState(guideTextColor ?? CoconutColors.onGray800(brightness));
+    final resolveGuideStyle =
+        guideStyle ?? CoconutTypography.caption_10.setColor(resolvedGuideTextColor);
+    final resolvedRadius = BorderRadius.only(
+      topRight: Radius.circular(borderRadius ?? 0),
+      topLeft: Radius.circular(borderRadius ?? 0),
+    );
+    final resolvedLabelColor = labelColor ?? CoconutColors.gray500;
+    final resolvedLabelStyle =
+        labelStyle ?? CoconutTypography.body3_12.setColor(resolvedLabelColor);
+    return Column(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        if (label != null) ...[
+          Align(
+            alignment: Alignment.centerLeft,
+            child: Text(
+              label!,
+              textAlign: TextAlign.start,
+              style: resolvedLabelStyle,
+            ),
+          )
+        ],
+        Material(
+          color: Colors.transparent,
+          child: InkWell(
+            onTap: enabled ? onTap : null,
+            // Ripple is limited to the tappable row above the divider.
+            borderRadius: resolvedRadius,
+            splashColor: CoconutColors.onBlack(brightness).withValues(alpha: 0.08),
+            highlightColor: CoconutColors.onBlack(brightness).withValues(alpha: 0.04),
+            child: Ink(
+              child: Padding(
+                padding: padding ?? EdgeInsets.fromLTRB(2, label != null ? 6 : 12, 4, 8),
+                child: Row(
+                  children: [
+                    Expanded(
+                      child: SingleChildScrollView(
+                        scrollDirection: Axis.horizontal,
+                        // Scroll the full inline content, including the leading text.
+                        child: Row(
+                          mainAxisSize: MainAxisSize.min,
+                          children: [
+                            Text(
+                              text,
+                              maxLines: 1,
+                              softWrap: false,
+                              style: resolvedTextStyle,
+                            ),
+                            for (final widget in inlineWidgets) ...[
+                              SizedBox(width: inlineSpacing),
+                              widget,
+                            ],
+                          ],
+                        ),
+                      ),
+                    ),
+                    const SizedBox(width: 8),
+                    SvgPicture.asset(
+                      'packages/coconut_design_system/assets/svg/pulldown_close.svg',
+                      width: iconSize,
+                      height: iconSize,
+                      colorFilter: ColorFilter.mode(
+                        resolvedIconColor,
+                        BlendMode.srcIn,
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+            ),
+          ),
+        ),
+        if (showDivider)
+          Divider(
+            height: 1,
+            thickness: 1,
+            color: resolvedDividerColor,
+          ),
+        if (coconutOptionStateEnum != CoconutOptionStateEnum.normal && guideText != null) ...[
+          Padding(
+            padding: const EdgeInsets.only(top: 4, left: 2),
+            child: Align(
+              alignment: Alignment.centerLeft,
+              child: Text(
+                guideText!,
+                style: resolveGuideStyle,
+              ),
+            ),
+          )
+        ]
+      ],
+    );
+  }
+}

--- a/lib/src/components/inputs/option-picker.dart
+++ b/lib/src/components/inputs/option-picker.dart
@@ -72,8 +72,8 @@ class CoconutOptionPicker extends StatelessWidget {
   /// ```
   const CoconutOptionPicker({
     super.key,
-    required this.text,
     required this.onTap,
+    this.text,
     this.enabled = true,
     this.label,
     this.guideText,
@@ -99,7 +99,7 @@ class CoconutOptionPicker extends StatelessWidget {
   /// The primary text displayed in the picker row.
   ///
   /// This usually represents the currently selected value.
-  final String text;
+  final String? text;
 
   /// An optional label displayed above the picker row.
   ///
@@ -218,18 +218,20 @@ class CoconutOptionPicker extends StatelessWidget {
     final resolvedLabelStyle =
         labelStyle ?? CoconutTypography.body3_12.setColor(resolvedLabelColor);
     final List<InlineSpan> wrappedContentSpans = [
-      TextSpan(
-        text: text,
-        style: resolvedTextStyle,
-      ),
-      for (final widget in inlineWidgets) ...[
-        WidgetSpan(
-          alignment: PlaceholderAlignment.middle,
-          child: SizedBox(width: inlineSpacing),
+      if (text != null)
+        TextSpan(
+          text: text,
+          style: resolvedTextStyle,
         ),
+      for (int index = 0; index < inlineWidgets.length; index++) ...[
+        if (text != null || index > 0)
+          WidgetSpan(
+            alignment: PlaceholderAlignment.middle,
+            child: SizedBox(width: inlineSpacing),
+          ),
         WidgetSpan(
           alignment: PlaceholderAlignment.middle,
-          child: widget,
+          child: inlineWidgets[index],
         ),
       ],
     ];
@@ -271,12 +273,14 @@ class CoconutOptionPicker extends StatelessWidget {
                               child: Row(
                                 mainAxisSize: MainAxisSize.min,
                                 children: [
-                                  Text(
-                                    text,
-                                    maxLines: 1,
-                                    softWrap: false,
-                                    style: resolvedTextStyle,
-                                  ),
+                                  if (text != null) ...[
+                                    Text(
+                                      text!,
+                                      maxLines: 1,
+                                      softWrap: false,
+                                      style: resolvedTextStyle,
+                                    ),
+                                  ],
                                   for (final widget in inlineWidgets) ...[
                                     SizedBox(width: inlineSpacing),
                                     widget,

--- a/lib/src/components/inputs/textfield.dart
+++ b/lib/src/components/inputs/textfield.dart
@@ -3,6 +3,12 @@ import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 
+/// The visual style of [CoconutTextField].
+enum CoconutTextFieldStyle {
+  bordered,
+  underline,
+}
+
 /// A customizable text field widget with a Cupertino-style appearance.
 ///
 /// `CoconutTextField` supports various customization options, including:
@@ -174,6 +180,11 @@ class CoconutTextField extends StatefulWidget {
   /// The line height applied to the input text.
   final double fontHeight;
 
+  /// The visual style of the text field.
+  ///
+  /// Defaults to [CoconutTextFieldStyle.bordered].
+  final CoconutTextFieldStyle style;
+
   /// Creates a `CoconutTextField` widget.
   ///
   /// - [controller] manages the text input.
@@ -261,7 +272,8 @@ class CoconutTextField extends StatefulWidget {
       this.enableSuggestions = false,
       this.enabled = true,
       this.textOverflow = TextOverflow.ellipsis,
-      this.fontHeight = 1.4});
+      this.fontHeight = 1.4,
+      this.style = CoconutTextFieldStyle.bordered});
 
   @override
   State<CoconutTextField> createState() => _CoconutTextFieldState();
@@ -345,6 +357,15 @@ class _CoconutTextFieldState extends State<CoconutTextField> {
 
   @override
   Widget build(BuildContext context) {
+    final bool isUnderline = widget.style == CoconutTextFieldStyle.underline;
+    final Color resolvedBorderColor = widget.isError
+        ? _errorColor
+        : _isFocus
+            ? widget.maxLength != null && _text.runes.length > widget.maxLength!
+                ? _errorColor
+                : _activeColor
+            : _placeholderColor;
+
     return Column(
       mainAxisSize: MainAxisSize.min,
       crossAxisAlignment: CrossAxisAlignment.stretch,
@@ -353,17 +374,18 @@ class _CoconutTextFieldState extends State<CoconutTextField> {
           height: widget.height,
           decoration: BoxDecoration(
             border: widget.isVisibleBorder
-                ? Border.all(
-                    color: widget.isError
-                        ? _errorColor
-                        : _isFocus
-                            ? widget.maxLength != null && _text.runes.length > widget.maxLength!
-                                ? _errorColor
-                                : _activeColor
-                            : _placeholderColor,
-                  )
+                ? isUnderline
+                    ? Border(
+                        bottom: BorderSide(
+                          color: resolvedBorderColor,
+                          width: 1,
+                        ),
+                      )
+                    : Border.all(
+                        color: resolvedBorderColor,
+                      )
                 : null,
-            borderRadius: BorderRadius.circular(widget.borderRadius),
+            borderRadius: isUnderline ? null : BorderRadius.circular(widget.borderRadius),
             color: _backgroundColor,
           ),
           child: Stack(
@@ -375,7 +397,12 @@ class _CoconutTextFieldState extends State<CoconutTextField> {
                 obscureText: widget.obscureText,
                 textAlign: widget.textAlign ?? TextAlign.start,
                 padding: widget.padding ??
-                    EdgeInsets.fromLTRB(widget.prefix != null ? 0 : 16, 20, 16, 20),
+                    EdgeInsets.fromLTRB(
+                      widget.prefix != null ? 0 : (isUnderline ? 0 : 16),
+                      isUnderline ? 12 : 20,
+                      isUnderline ? 0 : 16,
+                      isUnderline ? 12 : 20,
+                    ),
                 style: CoconutTypography.body2_14.copyWith(
                   color: _activeColor,
                   fontSize: widget.fontSize,
@@ -407,8 +434,17 @@ class _CoconutTextFieldState extends State<CoconutTextField> {
                 child: Container(
                   height: widget.prefix != null ? _prefixSize.height : null,
                   margin: widget.prefix == null
-                      ? widget.padding ?? const EdgeInsets.fromLTRB(16, 20, 16, 20)
-                      : EdgeInsets.only(left: _prefixSize.width, top: widget.padding?.top ?? 20),
+                      ? widget.padding ??
+                          EdgeInsets.fromLTRB(
+                            isUnderline ? 0 : 16,
+                            isUnderline ? 12 : 20,
+                            isUnderline ? 0 : 16,
+                            isUnderline ? 12 : 20,
+                          )
+                      : EdgeInsets.only(
+                          left: _prefixSize.width,
+                          top: widget.padding?.top ?? (isUnderline ? 12 : 20),
+                        ),
                   padding: widget.suffix != null ? const EdgeInsets.only(right: 40) : null,
                   alignment: Alignment.centerLeft,
                   child: widget.placeholderText == null || _isFocus || _text.isNotEmpty

--- a/lib/src/components/inputs/textfield.dart
+++ b/lib/src/components/inputs/textfield.dart
@@ -172,6 +172,11 @@ class CoconutTextField extends StatefulWidget {
   /// If `false`, the text field is disabled and does not respond to user input.
   final bool enabled;
 
+  /// Whether tapping outside the text field should remove focus.
+  ///
+  /// Defaults to `false`.
+  final bool unfocusOnTapOutside;
+
   /// The text overflow behavior of the text field.
   ///
   /// If `null`, it defaults to `TextOverflow.ellipsis`.
@@ -213,6 +218,7 @@ class CoconutTextField extends StatefulWidget {
   /// - [autocorrect] enables autocorrect.
   /// - [enableSuggestions] enables suggestions while typing.
   /// - [enabled] enables the text field.
+  /// - [unfocusOnTapOutside] removes focus when the user taps outside the field.
   /// - [textOverflow] controls the text overflow behavior.
   /// Example usage:
   /// ```dart
@@ -271,6 +277,7 @@ class CoconutTextField extends StatefulWidget {
       this.autocorrect = false,
       this.enableSuggestions = false,
       this.enabled = true,
+      this.unfocusOnTapOutside = false,
       this.textOverflow = TextOverflow.ellipsis,
       this.fontHeight = 1.4,
       this.style = CoconutTextFieldStyle.bordered});
@@ -428,6 +435,9 @@ class _CoconutTextFieldState extends State<CoconutTextField> {
                 autocorrect: widget.autocorrect,
                 enableSuggestions: widget.enableSuggestions,
                 onEditingComplete: widget.onEditingComplete,
+                onTapOutside: widget.unfocusOnTapOutside
+                    ? (_) => widget.focusNode.unfocus()
+                    : null,
                 enabled: widget.enabled,
               ),
               IgnorePointer(


### PR DESCRIPTION
## 추가사항
Coconut Option Picker 위젯
CoconutOptionPicker 예제 코드
Coconut_Animation

### 기능 설명
- 탭 시 onTap 콜백을 통해 원하는 액션 실행 가능
- 상단 라벨 표시 가능
- 텍스트 우측에 inlineWidgets로 보조 위젯을 함께 배치 가능
- 텍스트와 보조 위젯이 길어질 경우 가로 스크롤로 전체 내용 확인 가능
- 탭 영역에 ripple 효과 적용
- normal, warning, error 상태에 따라 시각적 상태 표현 가능
- warning, error 상태에서는 하단 가이드 문구 노출 가능
- 텍스트, 라벨, 아이콘, divider, 가이드 문구 스타일 커스텀 가능

### Coconut_Animation 사용법
Wallet에 Extension 추가
**(feat/645-utxo-consolidation의 lib/extensions/widget_animation_extensions.dart 참고)**

![Screen_Recording_20260403_101112](https://github.com/user-attachments/assets/a455d68e-1500-437e-9672-9f9e30fd1d27)

**Character.....관련 애니메이션**
- typewriterAnimation
- characterFadeInAnimation
- characterFadeOutAnimation
```dart
'UTXO 합치기 화면 (UTXO 개수: ${viewModel.utxoCount})'.characterFadeInAnimation(
            textStyle: const TextStyle(color: Colors.white), // Text Style 설정
            delay: const Duration(milliseconds: 300), // 0.3초 뒤에 애니메이션 시작
            duration: const Duration(milliseconds: 300), // 0.3초 동안 애니메이션 실행
          ),
```

![Screen_Recording_20260403_101042](https://github.com/user-attachments/assets/3bb9df2e-163e-4392-a86e-4edb6309d422)

**Animation Widgets**
- fadeInAnimation
- fadeOutAnimation
- bounceInAnimation
- bounceOutAnimation
- scaleInAnimation
- scaleOutAnimation
- shakeAnimation
- slideUpAnimation
- slideDownAnimation
- slideLeftAnimation
- slideRightAnimation
- transitionAnimation
- zoomInAnimation
- zoomOutAnimation
```dart
Text(
        'Hello',
        style: const TextStyle(fontSize: 24, color: Colors.white),
      ).fadeInAnimation(
        duration: const Duration(milliseconds: 300),
        curve: Curves.easeOut,
      ),
```

Character...Animation은 String extension,
AnimationWidget은 Widget extension 이기 때문에 사용법이 다릅니다.