### PR TITLE
Fix/coconut text field layout constraints

### DIFF
--- a/lib/src/components/inputs/textfield.dart
+++ b/lib/src/components/inputs/textfield.dart
@@ -505,17 +505,16 @@ class _CoconutTextFieldState extends State<CoconutTextField> {
                 ),
               ),
               if (widget.suffix != null)
-                Positioned.fill(
-                  child: Padding(
-                    padding: EdgeInsets.only(
-                      right: resolvedPadding.right,
-                    ),
-                    child: Align(
-                      alignment: Alignment.centerRight,
-                      child: KeyedSubtree(
-                        key: _suffixGlobalKey,
-                        child: widget.suffix!,
-                      ),
+                Positioned(
+                  right: resolvedPadding.right,
+                  top: 0,
+                  bottom: 0,
+                  child: Align(
+                    alignment: Alignment.centerRight,
+                    widthFactor: 1.0,
+                    child: KeyedSubtree(
+                      key: _suffixGlobalKey,
+                      child: widget.suffix!,
                     ),
                   ),
                 ),

--- a/lib/src/components/inputs/textfield.dart
+++ b/lib/src/components/inputs/textfield.dart
@@ -506,7 +506,7 @@ class _CoconutTextFieldState extends State<CoconutTextField> {
               ),
               if (widget.suffix != null)
                 Positioned(
-                  right: resolvedPadding.right,
+                  right: 0,
                   top: 0,
                   bottom: 0,
                   child: Align(

--- a/lib/src/components/inputs/textfield.dart
+++ b/lib/src/components/inputs/textfield.dart
@@ -330,7 +330,8 @@ class _CoconutTextFieldState extends State<CoconutTextField> {
   void _updateData() {
     _activeColor = widget.activeColor ?? CoconutColors.onBlack(brightness);
     _cursorColor = widget.cursorColor ?? CoconutColors.onBlack(brightness);
-    _placeholderColor = widget.placeholderColor ?? CoconutColors.onGray300(brightness);
+    _placeholderColor =
+        widget.placeholderColor ?? CoconutColors.onGray300(brightness);
     _errorColor = widget.errorColor ?? CoconutColors.red;
     _backgroundColor = widget.backgroundColor ?? Colors.transparent;
     _text = widget.controller.text;
@@ -365,12 +366,14 @@ class _CoconutTextFieldState extends State<CoconutTextField> {
     Size nextSuffixSize = const Size(0, 0);
 
     if (_prefixGlobalKey.currentContext != null) {
-      final prefixRenderBox = _prefixGlobalKey.currentContext?.findRenderObject() as RenderBox;
+      final prefixRenderBox =
+          _prefixGlobalKey.currentContext?.findRenderObject() as RenderBox;
       nextPrefixSize = prefixRenderBox.size;
     }
 
     if (_suffixGlobalKey.currentContext != null) {
-      final suffixRenderBox = _suffixGlobalKey.currentContext?.findRenderObject() as RenderBox;
+      final suffixRenderBox =
+          _suffixGlobalKey.currentContext?.findRenderObject() as RenderBox;
       nextSuffixSize = suffixRenderBox.size;
     }
 
@@ -419,7 +422,8 @@ class _CoconutTextFieldState extends State<CoconutTextField> {
                         color: resolvedBorderColor,
                       )
                 : null,
-            borderRadius: isUnderline ? null : BorderRadius.circular(widget.borderRadius),
+            borderRadius:
+                isUnderline ? null : BorderRadius.circular(widget.borderRadius),
             color: _backgroundColor,
           ),
           child: Stack(
@@ -458,21 +462,26 @@ class _CoconutTextFieldState extends State<CoconutTextField> {
                 autocorrect: widget.autocorrect,
                 enableSuggestions: widget.enableSuggestions,
                 onEditingComplete: widget.onEditingComplete,
-                onTapOutside: widget.unfocusOnTapOutside ? (_) => widget.focusNode.unfocus() : null,
+                onTapOutside: widget.unfocusOnTapOutside
+                    ? (_) => widget.focusNode.unfocus()
+                    : null,
                 enabled: widget.enabled,
               ),
               IgnorePointer(
                 child: Container(
-                  height: widget.prefix != null ? _prefixSize.height : null,
-                  margin: widget.prefix == null
-                      ? resolvedPadding
-                      : EdgeInsets.only(
-                          left: _prefixSize.width,
-                          top: resolvedPadding.top,
-                        ),
-                  padding: widget.suffix != null ? EdgeInsets.only(right: _suffixSize.width) : null,
+                  margin: EdgeInsets.only(
+                    left: widget.prefix == null
+                        ? resolvedPadding.left
+                        : _prefixSize.width,
+                    top: resolvedPadding.top,
+                    right: widget.suffix != null
+                        ? _suffixSize.width + resolvedPadding.right
+                        : resolvedPadding.right,
+                  ),
                   alignment: Alignment.centerLeft,
-                  child: widget.placeholderText == null || _isFocus || _text.isNotEmpty
+                  child: widget.placeholderText == null ||
+                          _isFocus ||
+                          _text.isNotEmpty
                       ? Text(
                           '',
                           style: CoconutTypography.body2_14.copyWith(
@@ -499,8 +508,7 @@ class _CoconutTextFieldState extends State<CoconutTextField> {
                 Positioned.fill(
                   child: Padding(
                     padding: EdgeInsets.only(
-                      top: resolvedPadding.top,
-                      bottom: resolvedPadding.bottom,
+                      right: resolvedPadding.right,
                     ),
                     child: Align(
                       alignment: Alignment.centerRight,

--- a/lib/src/components/inputs/textfield.dart
+++ b/lib/src/components/inputs/textfield.dart
@@ -330,8 +330,7 @@ class _CoconutTextFieldState extends State<CoconutTextField> {
   void _updateData() {
     _activeColor = widget.activeColor ?? CoconutColors.onBlack(brightness);
     _cursorColor = widget.cursorColor ?? CoconutColors.onBlack(brightness);
-    _placeholderColor =
-        widget.placeholderColor ?? CoconutColors.onGray300(brightness);
+    _placeholderColor = widget.placeholderColor ?? CoconutColors.onGray300(brightness);
     _errorColor = widget.errorColor ?? CoconutColors.red;
     _backgroundColor = widget.backgroundColor ?? Colors.transparent;
     _text = widget.controller.text;
@@ -366,14 +365,12 @@ class _CoconutTextFieldState extends State<CoconutTextField> {
     Size nextSuffixSize = const Size(0, 0);
 
     if (_prefixGlobalKey.currentContext != null) {
-      final prefixRenderBox =
-          _prefixGlobalKey.currentContext?.findRenderObject() as RenderBox;
+      final prefixRenderBox = _prefixGlobalKey.currentContext?.findRenderObject() as RenderBox;
       nextPrefixSize = prefixRenderBox.size;
     }
 
     if (_suffixGlobalKey.currentContext != null) {
-      final suffixRenderBox =
-          _suffixGlobalKey.currentContext?.findRenderObject() as RenderBox;
+      final suffixRenderBox = _suffixGlobalKey.currentContext?.findRenderObject() as RenderBox;
       nextSuffixSize = suffixRenderBox.size;
     }
 
@@ -422,8 +419,7 @@ class _CoconutTextFieldState extends State<CoconutTextField> {
                         color: resolvedBorderColor,
                       )
                 : null,
-            borderRadius:
-                isUnderline ? null : BorderRadius.circular(widget.borderRadius),
+            borderRadius: isUnderline ? null : BorderRadius.circular(widget.borderRadius),
             color: _backgroundColor,
           ),
           child: Stack(
@@ -462,26 +458,20 @@ class _CoconutTextFieldState extends State<CoconutTextField> {
                 autocorrect: widget.autocorrect,
                 enableSuggestions: widget.enableSuggestions,
                 onEditingComplete: widget.onEditingComplete,
-                onTapOutside: widget.unfocusOnTapOutside
-                    ? (_) => widget.focusNode.unfocus()
-                    : null,
+                onTapOutside: widget.unfocusOnTapOutside ? (_) => widget.focusNode.unfocus() : null,
                 enabled: widget.enabled,
               ),
               IgnorePointer(
                 child: Container(
                   margin: EdgeInsets.only(
-                    left: widget.prefix == null
-                        ? resolvedPadding.left
-                        : _prefixSize.width,
+                    left: widget.prefix == null ? resolvedPadding.left : _prefixSize.width,
                     top: resolvedPadding.top,
                     right: widget.suffix != null
                         ? _suffixSize.width + resolvedPadding.right
                         : resolvedPadding.right,
                   ),
                   alignment: Alignment.centerLeft,
-                  child: widget.placeholderText == null ||
-                          _isFocus ||
-                          _text.isNotEmpty
+                  child: widget.placeholderText == null || _isFocus || _text.isNotEmpty
                       ? Text(
                           '',
                           style: CoconutTypography.body2_14.copyWith(


### PR DESCRIPTION
#39 

## 변경 사항
- 텍스트필드 내 IgnorePointer(placeholder 표시용) 간격 로직 수정
- suffix != null인 경우 간격 수정

기타 수정사항: 볼트, 월렛에서 null이 아닌 빈 영역으로 전달하던 부분 null로 변경